### PR TITLE
Stabilize vendor metrics flow

### DIFF
--- a/api/app/routers/vendor_metrics.py
+++ b/api/app/routers/vendor_metrics.py
@@ -1,8 +1,9 @@
 import logging
 from fastapi import APIRouter, Depends, HTTPException, Security
 from fastapi.security.api_key import APIKeyHeader
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
-from app.models import User
+from app.models import AWSAPIConfiguration, DatadogAPIConfiguration, User
 from app.helpers.database import get_db
 from app.helpers.auth import get_authenticated_user
 from app.services.vendor_metrics_service import VendorMetricsService
@@ -10,15 +11,26 @@ from app.helpers.secrets_service import SecretsService
 
 API_KEY_NAME = "X-API-Key"
 api_key_header = APIKeyHeader(name=API_KEY_NAME, auto_error=True)
-secrets = SecretsService()
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/vendors-metrics", tags=["vendors"])
 
+VENDOR_CONFIG_MODELS = {
+    "aws": AWSAPIConfiguration,
+    "datadog": DatadogAPIConfiguration,
+}
 
-async def verify_api_key(api_key: str = Security(api_key_header)):
-    stored_api_key = secrets.get_secret("INTERNAL_API_KEY")
+
+def get_secrets_service() -> SecretsService:
+    return SecretsService()
+
+
+async def verify_api_key(
+    api_key: str = Security(api_key_header),
+    secrets_service: SecretsService = Depends(get_secrets_service),
+):
+    stored_api_key = secrets_service.get_secret("INTERNAL_API_KEY")
     if not stored_api_key:
         raise HTTPException(
             status_code=500,
@@ -49,8 +61,39 @@ async def get_vendor_metrics(
     db: Session = Depends(get_db),
 ):
     try:
+        vendor_name = vendor.lower()
+        config_model = VENDOR_CONFIG_MODELS.get(vendor_name)
+        if not config_model:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": "Invalid vendor",
+                    "message": f"Vendor type '{vendor}' not implemented",
+                    "code": "INVALID_VENDOR",
+                },
+            )
+
+        vendor_config = (
+            db.query(config_model)
+            .filter(config_model.user_id == user.id)
+            .filter(config_model.identifier == identifier)
+            .first()
+        )
+        if not vendor_config:
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "error": "Configuration not found",
+                    "message": (
+                        f"{vendor_name.upper()} API configuration not found "
+                        f"for this user with identifier {identifier}"
+                    ),
+                    "code": "CONFIG_NOT_FOUND",
+                },
+            )
+
         service = VendorMetricsService(user.id, db)
-        metrics = await service.get_and_store_vendor_metrics(vendor, identifier)
+        metrics = await service.get_and_store_vendor_metrics(vendor_name, identifier)
 
         # Sort metrics by date
         if isinstance(metrics, dict) and "data" in metrics:
@@ -64,17 +107,22 @@ async def get_vendor_metrics(
 
         return metrics
     except ValueError as e:
-        raise HTTPException(
+        return JSONResponse(
             status_code=400,
-            detail={
+            content={
+                "error": "Invalid vendor",
                 "message": str(e),
                 "code": "INVALID_VENDOR",
             },
         )
     except Exception as e:
-        raise HTTPException(
+        return JSONResponse(
             status_code=500,
-            detail={"message": str(e), "code": "VENDOR_ERROR"},
+            content={
+                "error": "Vendor metrics error",
+                "message": str(e),
+                "code": "VENDOR_ERROR",
+            },
         )
 
 

--- a/api/app/services/vendor_metrics_service.py
+++ b/api/app/services/vendor_metrics_service.py
@@ -85,6 +85,10 @@ class VendorMetricsService:
         self, vendor: str, identifier: str = "Default Configuration"
     ):
         """Get vendor metrics and store them in the database"""
+        vendor = vendor.lower()
+        if vendor not in {"aws", "datadog"}:
+            raise ValueError(f"Unsupported vendor: {vendor}")
+
         try:
             # Get stored metrics
             stored_metrics = (
@@ -92,7 +96,7 @@ class VendorMetricsService:
                 .filter(
                     and_(
                         VendorMetrics.user_id == self.user_id,
-                        VendorMetrics.vendor == vendor.lower(),
+                        VendorMetrics.vendor == vendor,
                         VendorMetrics.identifier == identifier,
                     )
                 )
@@ -165,7 +169,7 @@ class VendorMetricsService:
                 .filter(
                     and_(
                         VendorMetrics.user_id == self.user_id,
-                        VendorMetrics.vendor == vendor.lower(),
+                        VendorMetrics.vendor == vendor,
                         VendorMetrics.identifier == identifier,
                     )
                 )

--- a/api/app/tests/services/test_vendor_metrics_service.py
+++ b/api/app/tests/services/test_vendor_metrics_service.py
@@ -1,186 +1,160 @@
+from datetime import datetime
+from unittest.mock import Mock, patch
+
 import pytest
-from unittest.mock import Mock, patch, AsyncMock
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import (
+    AWSAPIConfiguration,
+    Base,
+    DatadogAPIConfiguration,
+    User,
+    VendorMetrics,
+)
 from app.services.vendor_metrics_service import VendorMetricsService
-from app.models import VendorMetrics, User, AWSAPIConfiguration, DatadogAPIConfiguration
 
 
 @pytest.fixture
-def mock_db():
-    db = Mock()
-    # Setup query.all() to return an empty list by default
-    db.query.return_value.all.return_value = []
-    return db
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
 
 
 @pytest.fixture
-def mock_user():
-    user = Mock(spec=User)
-    user.id = 1
+def user(db_session):
+    user = User(sub="test-user-123")
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
     return user
 
 
-@pytest.fixture
-def mock_aws_config():
-    config = Mock(spec=AWSAPIConfiguration)
-    config.identifier = "test-aws"
-    return config
-
-
-@pytest.fixture
-def mock_datadog_config():
-    config = Mock(spec=DatadogAPIConfiguration)
-    config.identifier = "test-datadog"
-    return config
+def shift_month(date: datetime, months: int) -> datetime:
+    month_index = date.month - 1 + months
+    year = date.year + month_index // 12
+    month = month_index % 12 + 1
+    return date.replace(year=year, month=month, day=1)
 
 
 @pytest.fixture
 def mock_costs_response():
+    current_month = datetime.now().replace(day=1)
+    previous_month = shift_month(current_month, -1)
     return {
         "data": [
-            {"month": "01-2024", "cost": 100.0},
-            {"month": "02-2024", "cost": 200.0},
+            {"month": previous_month.strftime("%m-%Y"), "cost": 100.0},
+            {"month": current_month.strftime("%m-%Y"), "cost": 200.0},
         ]
     }
+
+
+def metrics_by_month(response):
+    return {item["month"]: item["cost"] for item in response["data"]}
 
 
 class TestVendorMetricsService:
     @pytest.mark.asyncio
     async def test_get_and_store_vendor_metrics_aws_success(
-        self, mock_db, mock_user, mock_costs_response
+        self, db_session, user, mock_costs_response
     ):
-        """
-        GIVEN a VendorMetricsService instance and AWS vendor
-        WHEN get_and_store_vendor_metrics is called
-        THEN it should fetch costs and store them in the database
-        """
-        # GIVEN
-        service = VendorMetricsService(mock_user.id, mock_db)
-        mock_db.query.return_value.filter.return_value.first.return_value = None
+        service = VendorMetricsService(user.id, db_session)
 
         with patch(
             "app.services.vendor_metrics_service.AWSService",
             autospec=True,
         ) as mock_aws_service:
             mock_aws_instance = Mock()
-            mock_aws_instance.get_monthly_costs = AsyncMock(
-                return_value=mock_costs_response
-            )
+            mock_aws_instance.get_monthly_costs.return_value = mock_costs_response
             mock_aws_service.return_value = mock_aws_instance
 
-            # WHEN
             result = await service.get_and_store_vendor_metrics("aws", "test-config")
 
-            # THEN
-            assert result == mock_costs_response
-            assert mock_db.add.call_count == 2  # Two months of data
-            mock_db.commit.assert_called_once()
+        assert metrics_by_month(result) == metrics_by_month(mock_costs_response)
+        assert db_session.query(VendorMetrics).count() == 2
+        mock_aws_instance.get_monthly_costs.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_and_store_vendor_metrics_datadog_success(
-        self, mock_db, mock_user, mock_costs_response
+        self, db_session, user, mock_costs_response
     ):
-        """
-        GIVEN a VendorMetricsService instance and Datadog vendor
-        WHEN get_and_store_vendor_metrics is called
-        THEN it should fetch costs and store them in the database
-        """
-        # GIVEN
-        service = VendorMetricsService(mock_user.id, mock_db)
-        mock_db.query.return_value.filter.return_value.first.return_value = None
+        service = VendorMetricsService(user.id, db_session)
 
         with patch(
             "app.services.vendor_metrics_service.DatadogService",
             autospec=True,
         ) as mock_dd_service:
             mock_dd_instance = Mock()
-            mock_dd_instance.get_monthly_costs = AsyncMock(
-                return_value=mock_costs_response
-            )
+            mock_dd_instance.get_monthly_costs.return_value = mock_costs_response
             mock_dd_service.return_value = mock_dd_instance
 
-            # WHEN
             result = await service.get_and_store_vendor_metrics(
                 "datadog", "test-config"
             )
 
-            # THEN
-            assert result == mock_costs_response
-            assert mock_db.add.call_count == 2  # Two months of data
-            mock_db.commit.assert_called_once()
+        assert metrics_by_month(result) == metrics_by_month(mock_costs_response)
+        assert db_session.query(VendorMetrics).count() == 2
+        mock_dd_instance.get_monthly_costs.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_get_and_store_vendor_metrics_update_existing(
-        self, mock_db, mock_user, mock_costs_response
+        self, db_session, user, mock_costs_response
     ):
-        """
-        GIVEN a VendorMetricsService instance and existing metrics
-        WHEN get_and_store_vendor_metrics is called
-        THEN it should update existing metrics instead of creating new ones
-        """
-        # GIVEN
-        service = VendorMetricsService(mock_user.id, mock_db)
-        existing_metric = Mock(spec=VendorMetrics)
-        mock_db.query.return_value.filter.return_value.first.return_value = (
-            existing_metric
+        service = VendorMetricsService(user.id, db_session)
+        existing_month = mock_costs_response["data"][0]["month"]
+        existing_metric = VendorMetrics(
+            user_id=user.id,
+            vendor="aws",
+            identifier="test-config",
+            month=existing_month,
+            cost=10.0,
         )
+        db_session.add(existing_metric)
+        db_session.commit()
 
         with patch(
             "app.services.vendor_metrics_service.AWSService",
             autospec=True,
         ) as mock_aws_service:
             mock_aws_instance = Mock()
-            mock_aws_instance.get_monthly_costs = AsyncMock(
-                return_value=mock_costs_response
-            )
+            mock_aws_instance.get_monthly_costs.return_value = mock_costs_response
             mock_aws_service.return_value = mock_aws_instance
 
-            # WHEN
             result = await service.get_and_store_vendor_metrics("aws", "test-config")
 
-            # THEN
-            assert result == mock_costs_response
-            mock_db.add.assert_not_called()  # Should not add new records
-            mock_db.commit.assert_called_once()
-            assert existing_metric.cost == mock_costs_response["data"][1]["cost"]
+        db_session.refresh(existing_metric)
+        assert existing_metric.cost == mock_costs_response["data"][0]["cost"]
+        assert metrics_by_month(result) == metrics_by_month(mock_costs_response)
+        assert db_session.query(VendorMetrics).count() == 2
 
     @pytest.mark.asyncio
-    async def test_get_and_store_vendor_metrics_invalid_vendor(
-        self, mock_db, mock_user
-    ):
-        """
-        GIVEN a VendorMetricsService instance
-        WHEN get_and_store_vendor_metrics is called with invalid vendor
-        THEN it should raise ValueError
-        """
-        # GIVEN
-        service = VendorMetricsService(mock_user.id, mock_db)
+    async def test_get_and_store_vendor_metrics_invalid_vendor(self, db_session, user):
+        service = VendorMetricsService(user.id, db_session)
 
-        # WHEN/THEN
         with pytest.raises(ValueError, match="Unsupported vendor: invalid"):
             await service.get_and_store_vendor_metrics("invalid", "test-config")
 
     @pytest.mark.asyncio
     async def test_batch_update_all_vendor_metrics_success(
-        self,
-        mock_db,
-        mock_user,
-        mock_aws_config,
-        mock_datadog_config,
-        mock_costs_response,
+        self, db_session, user, mock_costs_response
     ):
-        """
-        GIVEN a database with users and their configurations
-        WHEN batch_update_all_vendor_metrics is called
-        THEN it should update metrics for all users and configurations
-        """
-        # GIVEN
-        mock_db.query.return_value.all.side_effect = [
-            [mock_user],  # Users query
-        ]
-        mock_db.query.return_value.filter.return_value.all.side_effect = [
-            [mock_aws_config],  # AWS configs query
-            [mock_datadog_config],  # Datadog configs query
-        ]
+        db_session.add_all(
+            [
+                AWSAPIConfiguration(user_id=user.id, identifier="test-aws"),
+                DatadogAPIConfiguration(user_id=user.id, identifier="test-datadog"),
+            ]
+        )
+        db_session.commit()
 
         with patch(
             "app.services.vendor_metrics_service.AWSService",
@@ -190,53 +164,33 @@ class TestVendorMetricsService:
             autospec=True,
         ) as mock_dd_service:
             mock_aws_instance = Mock()
-            mock_aws_instance.get_monthly_costs = AsyncMock(
-                return_value=mock_costs_response
-            )
+            mock_aws_instance.get_monthly_costs.return_value = mock_costs_response
             mock_aws_service.return_value = mock_aws_instance
 
             mock_dd_instance = Mock()
-            mock_dd_instance.get_monthly_costs = AsyncMock(
-                return_value=mock_costs_response
-            )
+            mock_dd_instance.get_monthly_costs.return_value = mock_costs_response
             mock_dd_service.return_value = mock_dd_instance
 
-            # Reset mock for storing metrics
-            mock_db.query.return_value.filter.return_value.first.return_value = None
-
-            # WHEN
             results = await VendorMetricsService.batch_update_all_vendor_metrics(
-                mock_db
+                db_session
             )
 
-            # THEN
-            assert len(results["success"]) == 2  # One success message for each config
-            assert len(results["failed"]) == 0
-            assert any("AWS metrics updated" in msg for msg in results["success"])
-            assert any("Datadog metrics updated" in msg for msg in results["success"])
+        assert len(results["success"]) == 2
+        assert len(results["failed"]) == 0
+        assert any("AWS metrics updated" in msg for msg in results["success"])
+        assert any("Datadog metrics updated" in msg for msg in results["success"])
 
     @pytest.mark.asyncio
     async def test_batch_update_all_vendor_metrics_partial_failure(
-        self,
-        mock_db,
-        mock_user,
-        mock_aws_config,
-        mock_datadog_config,
-        mock_costs_response,
+        self, db_session, user, mock_costs_response
     ):
-        """
-        GIVEN a database with users and their configurations
-        WHEN batch_update_all_vendor_metrics is called and some updates fail
-        THEN it should handle errors gracefully and continue processing
-        """
-        # GIVEN
-        mock_db.query.return_value.all.side_effect = [
-            [mock_user],  # Users query
-        ]
-        mock_db.query.return_value.filter.return_value.all.side_effect = [
-            [mock_aws_config],  # AWS configs query
-            [mock_datadog_config],  # Datadog configs query
-        ]
+        db_session.add_all(
+            [
+                AWSAPIConfiguration(user_id=user.id, identifier="test-aws"),
+                DatadogAPIConfiguration(user_id=user.id, identifier="test-datadog"),
+            ]
+        )
+        db_session.commit()
 
         with patch(
             "app.services.vendor_metrics_service.AWSService",
@@ -245,32 +199,23 @@ class TestVendorMetricsService:
             "app.services.vendor_metrics_service.DatadogService",
             autospec=True,
         ) as mock_dd_service:
-            # AWS service succeeds
             mock_aws_instance = Mock()
-            mock_aws_instance.get_monthly_costs = AsyncMock(
-                return_value=mock_costs_response
-            )
+            mock_aws_instance.get_monthly_costs.return_value = mock_costs_response
             mock_aws_service.return_value = mock_aws_instance
 
-            # Datadog service fails
             mock_dd_instance = Mock()
-            mock_dd_instance.get_monthly_costs = AsyncMock(
-                side_effect=Exception("Datadog API error")
+            mock_dd_instance.get_monthly_costs.side_effect = Exception(
+                "Datadog API error"
             )
             mock_dd_service.return_value = mock_dd_instance
 
-            # Reset mock for storing metrics
-            mock_db.query.return_value.filter.return_value.first.return_value = None
-
-            # WHEN
             results = await VendorMetricsService.batch_update_all_vendor_metrics(
-                mock_db
+                db_session
             )
 
-            # THEN
-            assert len(results["success"]) == 1  # AWS update succeeded
-            assert len(results["failed"]) == 1  # Datadog update failed
-            assert any("AWS metrics updated" in msg for msg in results["success"])
-            assert any(
-                "Failed to update Datadog metrics" in msg for msg in results["failed"]
-            )
+        assert len(results["success"]) == 1
+        assert len(results["failed"]) == 1
+        assert any("AWS metrics updated" in msg for msg in results["success"])
+        assert any(
+            "Failed to update Datadog metrics" in msg for msg in results["failed"]
+        )

--- a/dashboard/src/views/admin/default/components/VendorMetrics.tsx
+++ b/dashboard/src/views/admin/default/components/VendorMetrics.tsx
@@ -244,8 +244,12 @@ const VendorMetrics: React.FC<VendorMetricsProps> = ({ vendor, title, demo = fal
     try {
       const token = await getAccessTokenSilently();
       const backendUrl = process.env.REACT_APP_BACKEND_URL || '';
+      const query = new URLSearchParams({ format: "csv" });
+      if (identifier) {
+        query.set("identifier", identifier);
+      }
       const response = await fetch(
-        `${backendUrl}/v1/vendors-forecast/${vendor}?format=csv`,
+        `${backendUrl}/v1/vendors-forecast/${vendor}?${query.toString()}`,
         {
           headers: {
             Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary

- Make vendor metrics API key secret lookup lazy so importing the app does not require live Infisical credentials.
- Validate vendor names and configuration presence before fetching/storing metrics.
- Rewrite vendor metrics service tests around a real temporary SQLite session instead of stale chained mocks.
- Preserve the selected configuration identifier when exporting forecast CSV from the dashboard.

## Why

The API test suite was blocked by import-time `SecretsService()` initialization and tests that no longer matched the cached vendor metrics flow. The dashboard export path also fell back to the default forecast configuration because it omitted `identifier`.

## Validation

- `cd api && .venv/bin/python -m pytest -q`
- `cd dashboard && npm run build`
- `cd dashboard && npm test -- --watchAll=false --runInBand`