### PR TITLE
Normalize monthly cost adapter contract

### DIFF
--- a/api/app/routers/forecast.py
+++ b/api/app/routers/forecast.py
@@ -17,6 +17,7 @@ from app.services.forecast_service import ForecastService
 from app.services.datadog_service import DatadogService
 from app.services.aws_service import AWSService
 from app.services.heroku_service import HerokuService
+from app.services.monthly_costs import validate_monthly_cost_record
 
 logger = logging.getLogger(__name__)
 
@@ -127,8 +128,13 @@ async def get_vendor_forecast(
         if isinstance(historical_data, JSONResponse):
             return historical_data
 
+        historical_records = [
+            validate_monthly_cost_record(item, expected_provider=vendor_name)
+            for item in historical_data["data"]
+        ]
+
         # Generate forecast using the ForecastService
-        forecast_data = ForecastService.predict_mom_growth(historical_data["data"])
+        forecast_data = ForecastService.predict_mom_growth(historical_records)
 
         if format == "csv":
             output = io.StringIO()
@@ -186,7 +192,7 @@ async def get_vendor_forecast(
         return JSONResponse(
             status_code=200,
             content={
-                "historical": historical_data["data"],
+                "historical": historical_records,
                 "forecast": forecast_data["forecast_data"],
                 "sums": forecast_data["sums"],
                 "growth_rates": forecast_data["growth_rates"],

--- a/api/app/services/aws_service.py
+++ b/api/app/services/aws_service.py
@@ -4,6 +4,7 @@ from botocore.exceptions import ClientError
 from ..helpers.secrets_service import SecretsService
 from sqlalchemy.orm import Session
 from app.models import AWSAPIConfiguration
+from app.services.monthly_costs import build_monthly_cost_record
 import logging
 
 logger = logging.getLogger(__name__)
@@ -83,16 +84,28 @@ class AWSService:
 
             cost_data = []
             for result in response["ResultsByTime"]:
-                month = datetime.strptime(
-                    result["TimePeriod"]["Start"], "%Y-%m-%d"
-                ).strftime("%m-%Y")
-                cost = float(result["Total"]["UnblendedCost"]["Amount"])
-                cost_data.append(
-                    {
-                        "month": month,
-                        "cost": round(cost, 2),
-                    }
-                )
+                try:
+                    time_period = result["TimePeriod"]
+                    unblended_cost = result["Total"]["UnblendedCost"]
+                    period_start = datetime.strptime(
+                        time_period["Start"], "%Y-%m-%d"
+                    ).date()
+                    period_end = datetime.strptime(
+                        time_period["End"], "%Y-%m-%d"
+                    ).date()
+                    cost_data.append(
+                        build_monthly_cost_record(
+                            provider="aws",
+                            period_start=period_start,
+                            period_end=period_end,
+                            cost=unblended_cost["Amount"],
+                            currency=unblended_cost.get("Unit"),
+                        )
+                    )
+                except (KeyError, ValueError) as e:
+                    raise ValueError(
+                        "Malformed AWS Cost Explorer monthly cost row"
+                    ) from e
 
             return {"data": cost_data}
 

--- a/api/app/services/datadog_service.py
+++ b/api/app/services/datadog_service.py
@@ -7,6 +7,7 @@ from app.helpers.secrets_service import SecretsService
 from sqlalchemy.orm import Session
 import requests
 from app.models import DatadogAPIConfiguration
+from app.services.monthly_costs import add_month, build_monthly_cost_record
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,36 @@ class DatadogService:
         self.app_key = secrets.get_customer_secret(config.app_key)
         self.api_key = secrets.get_customer_secret(config.api_key)
         self.base_url = "https://api.datadoghq.com/api/v1"
+
+    @staticmethod
+    def _parse_usage_month_entry(entry: dict[str, Any]):
+        attributes = entry.get("attributes")
+        if not isinstance(attributes, dict):
+            raise ValueError("missing attributes")
+
+        date_value = attributes.get("date")
+        if not isinstance(date_value, str):
+            raise ValueError("missing attributes.date")
+
+        try:
+            period_start = datetime.fromisoformat(
+                date_value.replace("Z", "+00:00")
+            ).date()
+        except ValueError as exc:
+            raise ValueError("attributes.date must be ISO-like") from exc
+
+        # Datadog reports one date anchor per monthly row. Preserve that start
+        # and derive the exclusive next-month boundary for downstream lineage.
+        period_start = period_start.replace(day=1)
+        period_end = add_month(period_start)
+
+        return build_monthly_cost_record(
+            provider="datadog",
+            period_start=period_start,
+            period_end=period_end,
+            cost=attributes.get("total_cost"),
+            currency=None,
+        )
 
     def get_monthly_costs(
         self, start_date: str | None = None, end_date: str | None = None
@@ -69,19 +100,12 @@ class DatadogService:
                 monthly_costs = []
                 if "data" in data and isinstance(data["data"], list):
                     for entry in data["data"]:
-                        date = datetime.strptime(
-                            entry["attributes"]["date"], "%Y-%m-%dT%H:%M:%SZ"
-                        )
-                        monthly_costs.append(
-                            {
-                                "month": date.strftime(
-                                    "%m-%Y"
-                                ),  # Convert back to MM-YYYY for consistency
-                                "cost": round(
-                                    float(entry["attributes"]["total_cost"]), 2
-                                ),
-                            }
-                        )
+                        try:
+                            monthly_costs.append(self._parse_usage_month_entry(entry))
+                        except ValueError as exc:
+                            logger.warning(
+                                "Skipping malformed Datadog cost row: %s", exc
+                            )
                 return {"data": monthly_costs}
             else:
                 error_msg = (

--- a/api/app/services/heroku_service.py
+++ b/api/app/services/heroku_service.py
@@ -1,7 +1,8 @@
 """Heroku service module for handling Heroku Platform API interactions."""
 
 import logging
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 from typing import Any, Dict
 from urllib.parse import quote
 
@@ -10,6 +11,11 @@ from sqlalchemy.orm import Session
 
 from app.helpers.secrets_service import SecretsService
 from app.models import HerokuAPIConfiguration
+from app.services.monthly_costs import (
+    add_month,
+    build_monthly_cost_record,
+    decimal_cost,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,30 +47,60 @@ class HerokuService:
             raise Exception("Heroku API key not found")
 
     @staticmethod
-    def _add_months(date: datetime, months: int) -> datetime:
-        month_index = date.month - 1 + months
-        year = date.year + month_index // 12
+    def _add_months(date_value: date, months: int) -> date:
+        month_index = date_value.month - 1 + months
+        year = date_value.year + month_index // 12
         month = month_index % 12 + 1
-        return datetime(year, month, 1)
+        return date(year, month, 1)
 
     @staticmethod
-    def _month_start(month_year: str) -> datetime:
+    def _month_start(month_year: str) -> date:
         month, year = month_year.split("-")
-        return datetime(int(year), int(month), 1)
+        return date(int(year), int(month), 1)
 
     @staticmethod
-    def _parse_invoice_month(invoice: dict[str, Any]) -> datetime | None:
+    def _parse_heroku_date(value: Any) -> date | None:
+        if not value:
+            return None
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+        if not isinstance(value, str):
+            return None
+
+        for date_format in ("%m/%d/%Y", "%Y-%m-%d"):
+            try:
+                return datetime.strptime(value, date_format).date()
+            except ValueError:
+                pass
+
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
+        except ValueError:
+            return None
+
+    @classmethod
+    def _parse_invoice_period(cls, invoice: dict[str, Any]) -> tuple[date, date] | None:
         period_start = invoice.get("period_start")
-        if period_start:
-            return datetime.strptime(period_start, "%m/%d/%Y").replace(day=1)
+        start = cls._parse_heroku_date(period_start)
 
-        created_at = invoice.get("created_at")
-        if created_at:
-            return datetime.fromisoformat(created_at.replace("Z", "+00:00")).replace(
-                day=1, tzinfo=None
-            )
+        if not start:
+            created_at = invoice.get("created_at")
+            start = cls._parse_heroku_date(created_at)
+            if start:
+                start = start.replace(day=1)
 
-        return None
+        if not start:
+            return None
+
+        end = cls._parse_heroku_date(invoice.get("period_end"))
+        if not end:
+            # Some Heroku invoice payloads expose only a monthly anchor. In that
+            # case derive the exclusive next-month boundary and keep it explicit.
+            end = add_month(start.replace(day=1))
+
+        return start, end
 
     def _headers(self) -> dict[str, str]:
         return {
@@ -78,15 +114,29 @@ class HerokuService:
             return f"{self.base_url}/teams/{team}/invoices"
         return f"{self.base_url}/account/invoices"
 
-    def _invoice_total(self, invoice: dict[str, Any]) -> float:
-        total = invoice.get("total", invoice.get("charges_total", 0))
-        total_cost = float(total or 0)
+    def _invoice_total(self, invoice: dict[str, Any]) -> Decimal:
+        if "total" in invoice:
+            total = invoice["total"]
+        elif "charges_total" in invoice:
+            total = invoice["charges_total"]
+        else:
+            raise ValueError("missing invoice total")
+
+        total_cost = decimal_cost(total, "invoice total")
 
         # Team invoice totals are returned as integer cents by the Platform API.
         if self.team_name_or_id:
-            total_cost = total_cost / 100
+            total_cost = total_cost / Decimal("100")
 
-        return round(total_cost, 2)
+        return total_cost
+
+    @staticmethod
+    def _invoice_currency(invoice: dict[str, Any]) -> str | None:
+        for key in ("currency", "currency_code", "total_currency"):
+            currency = invoice.get(key)
+            if currency:
+                return str(currency)
+        return None
 
     def get_monthly_costs(
         self, start_date: str | None = None, end_date: str | None = None
@@ -126,21 +176,29 @@ class HerokuService:
 
             monthly_costs = []
             for invoice in response.json():
-                invoice_month = self._parse_invoice_month(invoice)
-                if not invoice_month:
+                invoice_period = self._parse_invoice_period(invoice)
+                if not invoice_period:
+                    logger.warning("Skipping Heroku invoice without usable period")
                     continue
 
-                if start_month <= invoice_month <= end_month:
-                    monthly_costs.append(
-                        {
-                            "month": invoice_month.strftime("%m-%Y"),
-                            "cost": self._invoice_total(invoice),
-                        }
-                    )
+                period_start, period_end = invoice_period
+                if not (start_month <= period_start.replace(day=1) <= end_month):
+                    continue
 
-            monthly_costs.sort(
-                key=lambda item: datetime.strptime(item["month"], "%m-%Y")
-            )
+                try:
+                    monthly_costs.append(
+                        build_monthly_cost_record(
+                            provider="heroku",
+                            period_start=period_start,
+                            period_end=period_end,
+                            cost=self._invoice_total(invoice),
+                            currency=self._invoice_currency(invoice),
+                        )
+                    )
+                except ValueError as exc:
+                    logger.warning("Skipping malformed Heroku invoice row: %s", exc)
+
+            monthly_costs.sort(key=lambda item: item["period_start"])
 
             return {"data": monthly_costs}
         except Exception as e:

--- a/api/app/services/monthly_costs.py
+++ b/api/app/services/monthly_costs.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any, Literal, Mapping, TypedDict, cast
+
+
+ProviderName = Literal["aws", "datadog", "heroku"]
+ALLOWED_PROVIDERS: set[str] = {"aws", "datadog", "heroku"}
+
+
+class MonthlyCostRecord(TypedDict):
+    month: str
+    cost: float
+    provider: ProviderName
+    period_start: str
+    period_end: str
+    currency: str | None
+
+
+def add_month(date_value: date) -> date:
+    month_index = date_value.month
+    year = date_value.year + month_index // 12
+    month = month_index % 12 + 1
+    return date(year, month, 1)
+
+
+def parse_iso_date(value: Any, field_name: str) -> date:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError(f"{field_name} must be an ISO date") from exc
+    raise ValueError(f"{field_name} must be an ISO date")
+
+
+def decimal_cost(value: Any, field_name: str = "cost") -> Decimal:
+    if value is None or value == "":
+        raise ValueError(f"{field_name} is required")
+
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"{field_name} must be numeric") from exc
+
+    if not amount.is_finite():
+        raise ValueError(f"{field_name} must be finite")
+
+    return amount
+
+
+def build_monthly_cost_record(
+    *,
+    provider: ProviderName,
+    period_start: date,
+    period_end: date,
+    cost: Any,
+    currency: Any = None,
+) -> MonthlyCostRecord:
+    if provider not in ALLOWED_PROVIDERS:
+        raise ValueError(f"Unsupported provider: {provider}")
+
+    if period_end <= period_start:
+        raise ValueError("period_end must be after period_start")
+
+    normalized_cost = decimal_cost(cost).quantize(Decimal("0.01"), ROUND_HALF_UP)
+    currency_value = str(currency).strip() if currency not in (None, "") else None
+
+    return {
+        "month": period_start.strftime("%m-%Y"),
+        "cost": float(normalized_cost),
+        "provider": provider,
+        "period_start": period_start.isoformat(),
+        "period_end": period_end.isoformat(),
+        "currency": currency_value,
+    }
+
+
+def validate_monthly_cost_record(
+    record: Mapping[str, Any], expected_provider: str | None = None
+) -> MonthlyCostRecord:
+    provider = str(record.get("provider", "")).lower()
+    if expected_provider and provider != expected_provider.lower():
+        raise ValueError(
+            f"Monthly cost provider {provider or '<missing>'} does not match "
+            f"expected provider {expected_provider.lower()}"
+        )
+    if provider not in ALLOWED_PROVIDERS:
+        raise ValueError("Monthly cost provider is required")
+
+    period_start = parse_iso_date(record.get("period_start"), "period_start")
+    period_end = parse_iso_date(record.get("period_end"), "period_end")
+    expected_month = period_start.strftime("%m-%Y")
+    if record.get("month") != expected_month:
+        raise ValueError("Monthly cost month must match period_start")
+
+    return build_monthly_cost_record(
+        provider=cast(ProviderName, provider),
+        period_start=period_start,
+        period_end=period_end,
+        cost=record.get("cost"),
+        currency=record.get("currency"),
+    )

--- a/api/app/services/vendor_metrics_service.py
+++ b/api/app/services/vendor_metrics_service.py
@@ -10,6 +10,7 @@ from app.models import (
 from app.services.aws_service import AWSService
 from app.services.datadog_service import DatadogService
 from app.services.heroku_service import HerokuService
+from app.services.monthly_costs import validate_monthly_cost_record
 from typing import List, Dict
 from datetime import datetime, timedelta
 import inspect
@@ -304,6 +305,9 @@ class VendorMetricsService:
     def _store_metrics(self, vendor: str, identifier: str, cost_data: list):
         """Store metrics in the database"""
         for cost_item in cost_data:
+            cost_record = validate_monthly_cost_record(
+                cost_item, expected_provider=vendor.lower()
+            )
             # Check if metric already exists
             existing_metric = (
                 self.db.query(VendorMetrics)
@@ -312,7 +316,7 @@ class VendorMetricsService:
                         VendorMetrics.user_id == self.user_id,
                         VendorMetrics.vendor == vendor.lower(),
                         VendorMetrics.identifier == identifier,
-                        VendorMetrics.month == cost_item["month"],
+                        VendorMetrics.month == cost_record["month"],
                     )
                 )
                 .first()
@@ -320,15 +324,15 @@ class VendorMetricsService:
 
             if existing_metric:
                 # Update existing metric
-                existing_metric.cost = cost_item["cost"]
+                existing_metric.cost = cost_record["cost"]
             else:
                 # Create new metric
                 metric = VendorMetrics(
                     user_id=self.user_id,
                     vendor=vendor.lower(),
                     identifier=identifier,
-                    month=cost_item["month"],
-                    cost=cost_item["cost"],
+                    month=cost_record["month"],
+                    cost=cost_record["cost"],
                 )
                 self.db.add(metric)
 

--- a/api/app/tests/services/test_aws_service.py
+++ b/api/app/tests/services/test_aws_service.py
@@ -1,0 +1,83 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from app.models import AWSAPIConfiguration
+from app.services.aws_service import AWSService
+
+
+@pytest.fixture
+def mock_db():
+    return Mock()
+
+
+def configure_query(mock_db, config):
+    mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
+        config
+    )
+
+
+def configured_service(mock_db, client):
+    config = Mock(spec=AWSAPIConfiguration)
+    config.aws_access_key_id = "aws-access-key-secret"
+    config.aws_secret_access_key = "aws-secret-key-secret"
+    configure_query(mock_db, config)
+
+    with patch("app.services.aws_service.SecretsService") as secrets, patch(
+        "app.services.aws_service.boto3.client", return_value=client
+    ):
+        secrets.return_value.get_customer_secret.side_effect = [
+            "aws-access-key",
+            "aws-secret-key",
+        ]
+        return AWSService(1, mock_db, "Default Configuration")
+
+
+def test_get_monthly_costs_maps_cost_explorer_lineage(mock_db):
+    client = Mock()
+    client.get_cost_and_usage.return_value = {
+        "ResultsByTime": [
+            {
+                "TimePeriod": {"Start": "2024-01-01", "End": "2024-02-01"},
+                "Total": {
+                    "UnblendedCost": {
+                        "Amount": "12.345",
+                        "Unit": "USD",
+                    }
+                },
+            }
+        ]
+    }
+
+    service = configured_service(mock_db, client)
+    result = service.get_monthly_costs("01-2024", "02-2024")
+
+    assert result == {
+        "data": [
+            {
+                "month": "01-2024",
+                "cost": 12.35,
+                "provider": "aws",
+                "period_start": "2024-01-01",
+                "period_end": "2024-02-01",
+                "currency": "USD",
+            }
+        ]
+    }
+
+
+def test_get_monthly_costs_fails_on_malformed_cost_explorer_row(mock_db):
+    client = Mock()
+    client.get_cost_and_usage.return_value = {
+        "ResultsByTime": [
+            {
+                "TimePeriod": {"Start": "2024-01-01", "End": "2024-02-01"},
+                "Total": {"UnblendedCost": {"Unit": "USD"}},
+            }
+        ]
+    }
+
+    service = configured_service(mock_db, client)
+
+    with pytest.raises(Exception, match="Malformed AWS Cost Explorer monthly cost row"):
+        service.get_monthly_costs("01-2024", "02-2024")

--- a/api/app/tests/services/test_datadog_service.py
+++ b/api/app/tests/services/test_datadog_service.py
@@ -1,0 +1,96 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from app.models import DatadogAPIConfiguration
+from app.services.datadog_service import DatadogService
+
+
+@pytest.fixture
+def mock_db():
+    return Mock()
+
+
+def configure_query(mock_db, config):
+    mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = (
+        config
+    )
+
+
+def configured_service(mock_db):
+    config = Mock(spec=DatadogAPIConfiguration)
+    config.app_key = "datadog-app-key-secret"
+    config.api_key = "datadog-api-key-secret"
+    configure_query(mock_db, config)
+
+    with patch("app.services.datadog_service.SecretsService") as secrets:
+        secrets.return_value.get_customer_secret.side_effect = [
+            "datadog-app-key",
+            "datadog-api-key",
+        ]
+        return DatadogService(1, mock_db, "Default Configuration")
+
+
+def test_get_monthly_costs_maps_month_anchor_and_null_currency(mock_db):
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "data": [
+            {
+                "attributes": {
+                    "date": "2024-01-01T00:00:00Z",
+                    "total_cost": "98.765",
+                }
+            }
+        ]
+    }
+
+    service = configured_service(mock_db)
+    with patch(
+        "app.services.datadog_service.requests.get", return_value=response
+    ) as requests_get:
+        result = service.get_monthly_costs("01-2024", "01-2024")
+
+    assert result == {
+        "data": [
+            {
+                "month": "01-2024",
+                "cost": 98.77,
+                "provider": "datadog",
+                "period_start": "2024-01-01",
+                "period_end": "2024-02-01",
+                "currency": None,
+            }
+        ]
+    }
+    requests_get.assert_called_once_with(
+        "https://api.datadoghq.com/api/v2/usage/historical_cost",
+        headers={
+            "DD-API-KEY": "datadog-api-key",
+            "DD-APPLICATION-KEY": "datadog-app-key",
+        },
+        params={"start_month": "2024-01", "end_month": "2024-01"},
+    )
+
+
+def test_get_monthly_costs_skips_malformed_rows_with_warning(mock_db, caplog):
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "data": [
+            {
+                "attributes": {
+                    "date": "2024-01-01T00:00:00Z",
+                }
+            }
+        ]
+    }
+
+    service = configured_service(mock_db)
+    caplog.set_level("WARNING")
+
+    with patch("app.services.datadog_service.requests.get", return_value=response):
+        result = service.get_monthly_costs("01-2024", "01-2024")
+
+    assert result == {"data": []}
+    assert "Skipping malformed Datadog cost row" in caplog.text

--- a/api/app/tests/services/test_heroku_service.py
+++ b/api/app/tests/services/test_heroku_service.py
@@ -27,7 +27,12 @@ def test_get_monthly_costs_uses_account_invoices(mock_db):
     response.status_code = 200
     response.json.return_value = [
         {"period_start": "12/01/2023", "total": 99.99},
-        {"period_start": "01/01/2024", "total": 120.50},
+        {
+            "period_start": "01/01/2024",
+            "period_end": "02/01/2024",
+            "total": 120.50,
+            "currency": "USD",
+        },
         {"period_start": "02/01/2024", "charges_total": 130.25},
         {"period_start": "04/01/2024", "total": 150.00},
     ]
@@ -42,8 +47,22 @@ def test_get_monthly_costs_uses_account_invoices(mock_db):
 
     assert result == {
         "data": [
-            {"month": "01-2024", "cost": 120.5},
-            {"month": "02-2024", "cost": 130.25},
+            {
+                "month": "01-2024",
+                "cost": 120.5,
+                "provider": "heroku",
+                "period_start": "2024-01-01",
+                "period_end": "2024-02-01",
+                "currency": "USD",
+            },
+            {
+                "month": "02-2024",
+                "cost": 130.25,
+                "provider": "heroku",
+                "period_start": "2024-02-01",
+                "period_end": "2024-03-01",
+                "currency": None,
+            },
         ]
     }
     requests_get.assert_called_once_with(
@@ -65,7 +84,7 @@ def test_get_monthly_costs_uses_team_invoices_and_normalizes_cents(mock_db):
     response = Mock()
     response.status_code = 200
     response.json.return_value = [
-        {"period_start": "01/01/2024", "total": 100000},
+        {"period_start": "01/01/2024", "total": 100000, "currency_code": "USD"},
         {"period_start": "02/01/2024", "charges_total": 75050},
     ]
 
@@ -79,8 +98,22 @@ def test_get_monthly_costs_uses_team_invoices_and_normalizes_cents(mock_db):
 
     assert result == {
         "data": [
-            {"month": "01-2024", "cost": 1000.0},
-            {"month": "02-2024", "cost": 750.5},
+            {
+                "month": "01-2024",
+                "cost": 1000.0,
+                "provider": "heroku",
+                "period_start": "2024-01-01",
+                "period_end": "2024-02-01",
+                "currency": "USD",
+            },
+            {
+                "month": "02-2024",
+                "cost": 750.5,
+                "provider": "heroku",
+                "period_start": "2024-02-01",
+                "period_end": "2024-03-01",
+                "currency": None,
+            },
         ]
     }
     requests_get.assert_called_once_with(
@@ -98,3 +131,30 @@ def test_missing_heroku_configuration_raises_error(mock_db):
 
     with pytest.raises(Exception, match="No Heroku configuration found"):
         HerokuService(1, mock_db, "Missing Configuration")
+
+
+def test_get_monthly_costs_skips_malformed_invoices(mock_db, caplog):
+    config = Mock(spec=HerokuAPIConfiguration)
+    config.api_key = "heroku-secret-id"
+    config.team_name_or_id = None
+    configure_query(mock_db, config)
+
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = [
+        {"period_start": "01/01/2024"},
+        {"total": 10.0},
+    ]
+
+    with patch("app.services.heroku_service.SecretsService") as secrets, patch(
+        "app.services.heroku_service.requests.get", return_value=response
+    ):
+        secrets.return_value.get_customer_secret.return_value = "heroku-token"
+
+        service = HerokuService(1, mock_db, "Default Configuration")
+        caplog.set_level("WARNING")
+        result = service.get_monthly_costs("01-2024", "01-2024")
+
+    assert result == {"data": []}
+    assert "Skipping malformed Heroku invoice row" in caplog.text
+    assert "Skipping Heroku invoice without usable period" in caplog.text

--- a/api/app/tests/services/test_vendor_metrics_service.py
+++ b/api/app/tests/services/test_vendor_metrics_service.py
@@ -13,6 +13,7 @@ from app.models import (
     User,
     VendorMetrics,
 )
+from app.services.monthly_costs import build_monthly_cost_record
 from app.services.vendor_metrics_service import VendorMetricsService
 
 
@@ -49,15 +50,31 @@ def shift_month(date: datetime, months: int) -> datetime:
 
 
 @pytest.fixture
-def mock_costs_response():
+def cost_response_for():
     current_month = datetime.now().replace(day=1)
     previous_month = shift_month(current_month, -1)
-    return {
-        "data": [
-            {"month": previous_month.strftime("%m-%Y"), "cost": 100.0},
-            {"month": current_month.strftime("%m-%Y"), "cost": 200.0},
-        ]
-    }
+
+    def _factory(provider):
+        return {
+            "data": [
+                build_monthly_cost_record(
+                    provider=provider,
+                    period_start=previous_month.date(),
+                    period_end=shift_month(previous_month, 1).date(),
+                    cost=100.0,
+                    currency="USD" if provider == "aws" else None,
+                ),
+                build_monthly_cost_record(
+                    provider=provider,
+                    period_start=current_month.date(),
+                    period_end=shift_month(current_month, 1).date(),
+                    cost=200.0,
+                    currency="USD" if provider == "aws" else None,
+                ),
+            ]
+        }
+
+    return _factory
 
 
 def metrics_by_month(response):
@@ -102,10 +119,11 @@ def add_heroku_config(db_session, user, identifier="test-config"):
 class TestVendorMetricsService:
     @pytest.mark.asyncio
     async def test_get_and_store_vendor_metrics_aws_success(
-        self, db_session, user, mock_costs_response
+        self, db_session, user, cost_response_for
     ):
         add_aws_config(db_session, user)
         service = VendorMetricsService(user.id, db_session)
+        mock_costs_response = cost_response_for("aws")
 
         with patch(
             "app.services.vendor_metrics_service.AWSService",
@@ -123,10 +141,11 @@ class TestVendorMetricsService:
 
     @pytest.mark.asyncio
     async def test_get_and_store_vendor_metrics_datadog_success(
-        self, db_session, user, mock_costs_response
+        self, db_session, user, cost_response_for
     ):
         add_datadog_config(db_session, user)
         service = VendorMetricsService(user.id, db_session)
+        mock_costs_response = cost_response_for("datadog")
 
         with patch(
             "app.services.vendor_metrics_service.DatadogService",
@@ -146,10 +165,11 @@ class TestVendorMetricsService:
 
     @pytest.mark.asyncio
     async def test_get_and_store_vendor_metrics_heroku_success(
-        self, db_session, user, mock_costs_response
+        self, db_session, user, cost_response_for
     ):
         add_heroku_config(db_session, user)
         service = VendorMetricsService(user.id, db_session)
+        mock_costs_response = cost_response_for("heroku")
 
         with patch(
             "app.services.vendor_metrics_service.HerokuService",
@@ -167,10 +187,11 @@ class TestVendorMetricsService:
 
     @pytest.mark.asyncio
     async def test_get_and_store_vendor_metrics_update_existing(
-        self, db_session, user, mock_costs_response
+        self, db_session, user, cost_response_for
     ):
         add_aws_config(db_session, user)
         service = VendorMetricsService(user.id, db_session)
+        mock_costs_response = cost_response_for("aws")
         existing_month = mock_costs_response["data"][0]["month"]
         existing_metric = VendorMetrics(
             user_id=user.id,
@@ -199,10 +220,11 @@ class TestVendorMetricsService:
 
     @pytest.mark.asyncio
     async def test_response_includes_freshness_fields_on_success(
-        self, db_session, user, mock_costs_response
+        self, db_session, user, cost_response_for
     ):
         add_aws_config(db_session, user)
         service = VendorMetricsService(user.id, db_session)
+        mock_costs_response = cost_response_for("aws")
         current_month = datetime.now().replace(day=1).strftime("%m-%Y")
 
         with patch(
@@ -277,9 +299,8 @@ class TestVendorMetricsService:
     @pytest.mark.asyncio
     async def test_partial_refresh_when_current_month_missing(self, db_session, user):
         add_aws_config(db_session, user)
-        previous_month = shift_month(datetime.now().replace(day=1), -1).strftime(
-            "%m-%Y"
-        )
+        previous_month_date = shift_month(datetime.now().replace(day=1), -1)
+        previous_month = previous_month_date.strftime("%m-%Y")
         db_session.add(
             VendorMetrics(
                 user_id=user.id,
@@ -300,7 +321,15 @@ class TestVendorMetricsService:
             mock_aws_instance = Mock()
             # Vendor returns data but omits the current month.
             mock_aws_instance.get_monthly_costs.return_value = {
-                "data": [{"month": previous_month, "cost": 100.0}]
+                "data": [
+                    build_monthly_cost_record(
+                        provider="aws",
+                        period_start=previous_month_date.date(),
+                        period_end=shift_month(previous_month_date, 1).date(),
+                        cost=100.0,
+                        currency="USD",
+                    )
+                ]
             }
             mock_aws_service.return_value = mock_aws_instance
 
@@ -338,11 +367,14 @@ class TestVendorMetricsService:
 
     @pytest.mark.asyncio
     async def test_batch_update_all_vendor_metrics_success(
-        self, db_session, user, mock_costs_response
+        self, db_session, user, cost_response_for
     ):
         add_aws_config(db_session, user, "test-aws")
         add_datadog_config(db_session, user, "test-datadog")
         add_heroku_config(db_session, user, "test-heroku")
+        aws_response = cost_response_for("aws")
+        datadog_response = cost_response_for("datadog")
+        heroku_response = cost_response_for("heroku")
 
         with patch(
             "app.services.vendor_metrics_service.AWSService",
@@ -355,15 +387,15 @@ class TestVendorMetricsService:
             autospec=True,
         ) as mock_heroku_service:
             mock_aws_instance = Mock()
-            mock_aws_instance.get_monthly_costs.return_value = mock_costs_response
+            mock_aws_instance.get_monthly_costs.return_value = aws_response
             mock_aws_service.return_value = mock_aws_instance
 
             mock_dd_instance = Mock()
-            mock_dd_instance.get_monthly_costs.return_value = mock_costs_response
+            mock_dd_instance.get_monthly_costs.return_value = datadog_response
             mock_dd_service.return_value = mock_dd_instance
 
             mock_heroku_instance = Mock()
-            mock_heroku_instance.get_monthly_costs.return_value = mock_costs_response
+            mock_heroku_instance.get_monthly_costs.return_value = heroku_response
             mock_heroku_service.return_value = mock_heroku_instance
 
             results = await VendorMetricsService.batch_update_all_vendor_metrics(
@@ -378,11 +410,13 @@ class TestVendorMetricsService:
 
     @pytest.mark.asyncio
     async def test_batch_update_all_vendor_metrics_partial_failure(
-        self, db_session, user, mock_costs_response
+        self, db_session, user, cost_response_for
     ):
         add_aws_config(db_session, user, "test-aws")
         add_datadog_config(db_session, user, "test-datadog")
         add_heroku_config(db_session, user, "test-heroku")
+        aws_response = cost_response_for("aws")
+        heroku_response = cost_response_for("heroku")
 
         with patch(
             "app.services.vendor_metrics_service.AWSService",
@@ -395,7 +429,7 @@ class TestVendorMetricsService:
             autospec=True,
         ) as mock_heroku_service:
             mock_aws_instance = Mock()
-            mock_aws_instance.get_monthly_costs.return_value = mock_costs_response
+            mock_aws_instance.get_monthly_costs.return_value = aws_response
             mock_aws_service.return_value = mock_aws_instance
 
             mock_dd_instance = Mock()
@@ -405,7 +439,7 @@ class TestVendorMetricsService:
             mock_dd_service.return_value = mock_dd_instance
 
             mock_heroku_instance = Mock()
-            mock_heroku_instance.get_monthly_costs.return_value = mock_costs_response
+            mock_heroku_instance.get_monthly_costs.return_value = heroku_response
             mock_heroku_service.return_value = mock_heroku_instance
 
             results = await VendorMetricsService.batch_update_all_vendor_metrics(


### PR DESCRIPTION
## Why

Product Brain Q-001 calls for a shared monthly-cost adapter contract so AWS, Datadog, and Heroku expose provider/source metadata before later lineage persistence work. The previous adapter boundary only returned `month` and `cost`, which discarded AWS Cost Explorer intervals/currency and gave downstream code no way to distinguish provider-reported metadata from unknown values.

## What changed

- Added a shared monthly cost record contract with `month`, `cost`, `provider`, `period_start`, `period_end`, and nullable `currency`.
- Updated AWS to preserve Cost Explorer `TimePeriod` and `UnblendedCost.Unit`.
- Updated Datadog to derive the exclusive next-month boundary from its monthly date anchor and keep currency unknown as `null`.
- Updated Heroku invoice mapping to preserve available invoice period/currency fields, derive a next-month boundary when only a month anchor exists, and skip malformed invoice rows instead of turning them into zero-cost rows.
- Updated vendor metrics and forecast consumers to validate adapter rows through the shared contract while keeping existing `month`/`cost` behavior compatible.
- Added mocked adapter coverage for AWS and Datadog, and expanded Heroku/vendor-metrics service tests, including the source-health tests now on `main`.

## Validation

- `uv run --extra dev pytest -q` -> 24 passed
- `uv run --extra dev black --check app` -> clean
- `uv run --extra dev flake8 app` -> clean
- `git diff --check` -> clean

## Note

A touched-file mypy check is currently blocked before file analysis by the existing SQLAlchemy mypy plugin conflict with installed SQLAlchemy stubs.