### PR TITLE
Persist monthly cost lineage

### DIFF
--- a/api/app/migrations/__init__.py
+++ b/api/app/migrations/__init__.py
@@ -9,6 +9,7 @@ from .create_vendor_metrics_table import upgrade as create_vendor_metrics_table
 from .add_updated_at_to_vendor_metrics import (
     upgrade as add_updated_at_to_vendor_metrics,
 )
+from .add_lineage_to_vendor_metrics import upgrade as add_lineage_to_vendor_metrics
 
 # List of migrations in order of execution
 MIGRATIONS = [
@@ -19,4 +20,5 @@ MIGRATIONS = [
     add_config_name,
     create_vendor_metrics_table,  # Add vendor metrics table
     add_updated_at_to_vendor_metrics,  # Add the new migration
+    add_lineage_to_vendor_metrics,
 ]

--- a/api/app/migrations/add_lineage_to_vendor_metrics.py
+++ b/api/app/migrations/add_lineage_to_vendor_metrics.py
@@ -1,0 +1,58 @@
+import logging
+from sqlalchemy import text
+from app.helpers.database import engine
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def upgrade():
+    logger.info("Starting migration: Adding lineage columns to vendor metrics")
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    ALTER TABLE vendor_metrics
+                    ADD COLUMN IF NOT EXISTS source_provider VARCHAR;
+                    ALTER TABLE vendor_metrics
+                    ADD COLUMN IF NOT EXISTS source_period_start DATE;
+                    ALTER TABLE vendor_metrics
+                    ADD COLUMN IF NOT EXISTS source_period_end DATE;
+                    ALTER TABLE vendor_metrics
+                    ADD COLUMN IF NOT EXISTS provider_currency VARCHAR;
+                    """
+                )
+            )
+            logger.info("Added vendor metrics lineage columns successfully")
+    except Exception:
+        logger.exception("Migration failed")
+        raise
+
+
+def downgrade():
+    logger.info("Starting downgrade: Removing lineage columns from vendor metrics")
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    ALTER TABLE vendor_metrics
+                    DROP COLUMN IF EXISTS provider_currency;
+                    ALTER TABLE vendor_metrics
+                    DROP COLUMN IF EXISTS source_period_end;
+                    ALTER TABLE vendor_metrics
+                    DROP COLUMN IF EXISTS source_period_start;
+                    ALTER TABLE vendor_metrics
+                    DROP COLUMN IF EXISTS source_provider;
+                    """
+                )
+            )
+            logger.info("Removed vendor metrics lineage columns successfully")
+    except Exception:
+        logger.exception("Downgrade failed")
+        raise
+
+
+if __name__ == "__main__":
+    upgrade()

--- a/api/app/migrations/create_vendor_metrics_table.py
+++ b/api/app/migrations/create_vendor_metrics_table.py
@@ -22,6 +22,10 @@ def upgrade():
                         identifier VARCHAR NOT NULL,
                         month VARCHAR NOT NULL,
                         cost FLOAT NOT NULL,
+                        source_provider VARCHAR NULL,
+                        source_period_start DATE NULL,
+                        source_period_end DATE NULL,
+                        provider_currency VARCHAR NULL,
                         created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
                         CONSTRAINT uq_vendor_metrics_user_vendor_identifier_month
                             UNIQUE (user_id, vendor, identifier, month)

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, JSON
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, JSON, Date
 from sqlalchemy.orm import relationship, declared_attr
 from sqlalchemy.ext.declarative import declarative_base
 from datetime import datetime
@@ -106,6 +106,10 @@ class VendorMetrics(Base):
     identifier = Column(String)  # Configuration identifier
     month = Column(String)  # Format: MM-YYYY
     cost = Column(sqlalchemy.Float)
+    source_provider = Column(String, nullable=True)
+    source_period_start = Column(Date, nullable=True)
+    source_period_end = Column(Date, nullable=True)
+    provider_currency = Column(String, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/api/app/services/vendor_metrics_service.py
+++ b/api/app/services/vendor_metrics_service.py
@@ -10,7 +10,7 @@ from app.models import (
 from app.services.aws_service import AWSService
 from app.services.datadog_service import DatadogService
 from app.services.heroku_service import HerokuService
-from app.services.monthly_costs import validate_monthly_cost_record
+from app.services.monthly_costs import parse_iso_date, validate_monthly_cost_record
 from typing import List, Dict
 from datetime import datetime, timedelta
 import inspect
@@ -42,6 +42,23 @@ def _iso_utc(dt: datetime | None) -> str | None:
     if dt is None:
         return None
     return dt.replace(microsecond=0).isoformat() + "Z"
+
+
+def _date_iso(date_value) -> str | None:
+    if date_value is None:
+        return None
+    return date_value.isoformat()
+
+
+def _serialize_metric(metric: VendorMetrics):
+    return {
+        "month": metric.month,
+        "cost": float(metric.cost),
+        "source_provider": metric.source_provider or "unknown",
+        "source_period_start": _date_iso(metric.source_period_start),
+        "source_period_end": _date_iso(metric.source_period_end),
+        "provider_currency": metric.provider_currency,
+    }
 
 
 class VendorMetricsService:
@@ -229,7 +246,7 @@ class VendorMetricsService:
             )
 
             data = [
-                {"month": metric.month, "cost": float(metric.cost)}
+                _serialize_metric(metric)
                 for metric in all_metrics
                 if datetime.strptime(metric.month, "%m-%Y").year
                 > datetime.now().year - 2
@@ -308,6 +325,10 @@ class VendorMetricsService:
             cost_record = validate_monthly_cost_record(
                 cost_item, expected_provider=vendor.lower()
             )
+            source_period_start = parse_iso_date(
+                cost_record["period_start"], "period_start"
+            )
+            source_period_end = parse_iso_date(cost_record["period_end"], "period_end")
             # Check if metric already exists
             existing_metric = (
                 self.db.query(VendorMetrics)
@@ -325,6 +346,10 @@ class VendorMetricsService:
             if existing_metric:
                 # Update existing metric
                 existing_metric.cost = cost_record["cost"]
+                existing_metric.source_provider = cost_record["provider"]
+                existing_metric.source_period_start = source_period_start
+                existing_metric.source_period_end = source_period_end
+                existing_metric.provider_currency = cost_record["currency"]
             else:
                 # Create new metric
                 metric = VendorMetrics(
@@ -333,6 +358,10 @@ class VendorMetricsService:
                     identifier=identifier,
                     month=cost_record["month"],
                     cost=cost_record["cost"],
+                    source_provider=cost_record["provider"],
+                    source_period_start=source_period_start,
+                    source_period_end=source_period_end,
+                    provider_currency=cost_record["currency"],
                 )
                 self.db.add(metric)
 

--- a/api/app/tests/services/test_vendor_metrics_service.py
+++ b/api/app/tests/services/test_vendor_metrics_service.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 from app.models import (
@@ -81,6 +82,10 @@ def metrics_by_month(response):
     return {item["month"]: item["cost"] for item in response["data"]}
 
 
+def lineage_by_month(response):
+    return {item["month"]: item for item in response["data"]}
+
+
 def add_aws_config(db_session, user, identifier="test-config"):
     config = AWSAPIConfiguration(
         user_id=user.id,
@@ -137,6 +142,34 @@ class TestVendorMetricsService:
 
         assert metrics_by_month(result) == metrics_by_month(mock_costs_response)
         assert db_session.query(VendorMetrics).count() == 2
+        stored_metric = (
+            db_session.query(VendorMetrics)
+            .filter(VendorMetrics.month == mock_costs_response["data"][0]["month"])
+            .first()
+        )
+        assert stored_metric.source_provider == "aws"
+        assert (
+            stored_metric.source_period_start.isoformat()
+            == mock_costs_response["data"][0]["period_start"]
+        )
+        assert (
+            stored_metric.source_period_end.isoformat()
+            == mock_costs_response["data"][0]["period_end"]
+        )
+        assert stored_metric.provider_currency == "USD"
+        result_metric = lineage_by_month(result)[
+            mock_costs_response["data"][0]["month"]
+        ]
+        assert result_metric["source_provider"] == "aws"
+        assert (
+            result_metric["source_period_start"]
+            == mock_costs_response["data"][0]["period_start"]
+        )
+        assert (
+            result_metric["source_period_end"]
+            == mock_costs_response["data"][0]["period_end"]
+        )
+        assert result_metric["provider_currency"] == "USD"
         mock_aws_instance.get_monthly_costs.assert_called_once()
 
     @pytest.mark.asyncio
@@ -215,8 +248,81 @@ class TestVendorMetricsService:
 
         db_session.refresh(existing_metric)
         assert existing_metric.cost == mock_costs_response["data"][0]["cost"]
+        assert existing_metric.source_provider == "aws"
+        assert (
+            existing_metric.source_period_start.isoformat()
+            == mock_costs_response["data"][0]["period_start"]
+        )
+        assert (
+            existing_metric.source_period_end.isoformat()
+            == mock_costs_response["data"][0]["period_end"]
+        )
+        assert existing_metric.provider_currency == "USD"
         assert metrics_by_month(result) == metrics_by_month(mock_costs_response)
         assert db_session.query(VendorMetrics).count() == 2
+
+    @pytest.mark.asyncio
+    async def test_historical_metrics_with_unknown_lineage_are_explicit(
+        self, db_session, user
+    ):
+        add_aws_config(db_session, user)
+        previous_month = shift_month(datetime.now().replace(day=1), -1).strftime(
+            "%m-%Y"
+        )
+        db_session.add(
+            VendorMetrics(
+                user_id=user.id,
+                vendor="aws",
+                identifier="test-config",
+                month=previous_month,
+                cost=42.0,
+            )
+        )
+        db_session.commit()
+
+        service = VendorMetricsService(user.id, db_session)
+
+        with patch(
+            "app.services.vendor_metrics_service.AWSService",
+            autospec=True,
+        ) as mock_aws_service:
+            mock_aws_instance = Mock()
+            mock_aws_instance.get_monthly_costs.return_value = {"data": []}
+            mock_aws_service.return_value = mock_aws_instance
+
+            result = await service.get_and_store_vendor_metrics("aws", "test-config")
+
+        historical_metric = lineage_by_month(result)[previous_month]
+        assert historical_metric["source_provider"] == "unknown"
+        assert historical_metric["source_period_start"] is None
+        assert historical_metric["source_period_end"] is None
+        assert historical_metric["provider_currency"] is None
+
+    def test_uniqueness_by_user_vendor_identifier_and_month_remains_enforced(
+        self, db_session, user
+    ):
+        first_metric = VendorMetrics(
+            user_id=user.id,
+            vendor="aws",
+            identifier="test-config",
+            month="01-2026",
+            cost=10.0,
+            source_provider="aws",
+        )
+        duplicate_metric = VendorMetrics(
+            user_id=user.id,
+            vendor="aws",
+            identifier="test-config",
+            month="01-2026",
+            cost=20.0,
+            source_provider="aws",
+        )
+        db_session.add(first_metric)
+        db_session.commit()
+
+        db_session.add(duplicate_metric)
+        with pytest.raises(IntegrityError):
+            db_session.commit()
 
     @pytest.mark.asyncio
     async def test_response_includes_freshness_fields_on_success(

--- a/api/app/tests/test_vendor_metrics.py
+++ b/api/app/tests/test_vendor_metrics.py
@@ -1,3 +1,18 @@
+from datetime import datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+from app.models import AWSAPIConfiguration, User, VendorMetrics
+from app.tests.conftest import TestingSessionLocal
+
+
+def shift_month(date_value: datetime, months: int) -> datetime:
+    month_index = date_value.month - 1 + months
+    year = date_value.year + month_index // 12
+    month = month_index % 12 + 1
+    return date_value.replace(year=year, month=month, day=1)
+
+
 def test_get_vendor_metrics_invalid_vendor(test_client):
     response = test_client.get("/v1/vendors-metrics/invalid_vendor")
 
@@ -10,3 +25,80 @@ def test_get_vendor_metrics_no_config(test_client):
 
     assert response.status_code == 404
     assert response.json()["code"] == "CONFIG_NOT_FOUND"
+
+
+def test_get_vendor_metrics_returns_lineage_without_cross_scope_leaks(test_client):
+    identifier = f"route-scope-{uuid4()}"
+    other_identifier = f"{identifier}-other"
+    month_start = shift_month(datetime.now().replace(day=1), -1).date()
+    month_end = shift_month(datetime.now().replace(day=1), 0).date()
+    month = month_start.strftime("%m-%Y")
+
+    db = TestingSessionLocal()
+    try:
+        current_user = db.query(User).filter(User.sub == "test-user-123").first()
+        other_user = User(sub=f"other-user-{uuid4()}")
+        db.add(other_user)
+        db.flush()
+        db.add(
+            AWSAPIConfiguration(
+                user_id=current_user.id,
+                identifier=identifier,
+                aws_access_key_id="aws-key",
+                aws_secret_access_key="aws-secret",
+            )
+        )
+        db.add(
+            VendorMetrics(
+                user_id=current_user.id,
+                vendor="aws",
+                identifier=identifier,
+                month=month,
+                cost=123.45,
+                source_provider="aws",
+                source_period_start=month_start,
+                source_period_end=month_end,
+                provider_currency="USD",
+            )
+        )
+        db.add(
+            VendorMetrics(
+                user_id=current_user.id,
+                vendor="aws",
+                identifier=other_identifier,
+                month=month,
+                cost=888.88,
+            )
+        )
+        db.add(
+            VendorMetrics(
+                user_id=other_user.id,
+                vendor="aws",
+                identifier=identifier,
+                month=month,
+                cost=999.99,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    with patch(
+        "app.services.vendor_metrics_service.VendorMetricsService._get_vendor_costs",
+        return_value={"data": []},
+    ):
+        response = test_client.get(f"/v1/vendors-metrics/aws?identifier={identifier}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["record_count"] == 1
+    assert body["data"] == [
+        {
+            "month": month,
+            "cost": 123.45,
+            "source_provider": "aws",
+            "source_period_start": month_start.isoformat(),
+            "source_period_end": month_end.isoformat(),
+            "provider_currency": "USD",
+        }
+    ]

--- a/api/app/tests/test_vendor_metrics_migrations.py
+++ b/api/app/tests/test_vendor_metrics_migrations.py
@@ -1,0 +1,102 @@
+from importlib import import_module
+
+import pytest
+
+from app.migrations import MIGRATIONS
+
+
+class FakeConnection:
+    def __init__(self):
+        self.statements = []
+
+    def execute(self, statement):
+        self.statements.append(str(statement))
+
+
+class FakeBegin:
+    def __init__(self, connection):
+        self.connection = connection
+
+    def __enter__(self):
+        return self.connection
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+class FakeEngine:
+    def __init__(self):
+        self.connection = FakeConnection()
+
+    def begin(self):
+        return FakeBegin(self.connection)
+
+
+class FailingEngine:
+    def begin(self):
+        raise RuntimeError("database unavailable")
+
+
+def captured_sql(fake_engine):
+    return "\n".join(fake_engine.connection.statements)
+
+
+def test_create_vendor_metrics_table_includes_nullable_lineage_columns(monkeypatch):
+    migration = import_module("app.migrations.create_vendor_metrics_table")
+    fake_engine = FakeEngine()
+    monkeypatch.setattr(migration, "engine", fake_engine)
+
+    migration.upgrade()
+
+    sql = captured_sql(fake_engine)
+    assert "source_provider VARCHAR NULL" in sql
+    assert "source_period_start DATE NULL" in sql
+    assert "source_period_end DATE NULL" in sql
+    assert "provider_currency VARCHAR NULL" in sql
+    assert "UNIQUE (user_id, vendor, identifier, month)" in sql
+
+
+def test_add_lineage_migration_is_additive_nullable_and_registered(monkeypatch):
+    migration = import_module("app.migrations.add_lineage_to_vendor_metrics")
+    fake_engine = FakeEngine()
+    monkeypatch.setattr(migration, "engine", fake_engine)
+
+    migration.upgrade()
+
+    sql = captured_sql(fake_engine)
+    assert MIGRATIONS[-1] is migration.upgrade
+    assert "ADD COLUMN IF NOT EXISTS source_provider VARCHAR" in sql
+    assert "ADD COLUMN IF NOT EXISTS source_period_start DATE" in sql
+    assert "ADD COLUMN IF NOT EXISTS source_period_end DATE" in sql
+    assert "ADD COLUMN IF NOT EXISTS provider_currency VARCHAR" in sql
+    assert "DEFAULT" not in sql.upper()
+
+
+def test_add_lineage_downgrade_drops_nullable_lineage_columns(monkeypatch):
+    migration = import_module("app.migrations.add_lineage_to_vendor_metrics")
+    fake_engine = FakeEngine()
+    monkeypatch.setattr(migration, "engine", fake_engine)
+
+    migration.downgrade()
+
+    sql = captured_sql(fake_engine)
+    assert "DROP COLUMN IF EXISTS provider_currency" in sql
+    assert "DROP COLUMN IF EXISTS source_period_end" in sql
+    assert "DROP COLUMN IF EXISTS source_period_start" in sql
+    assert "DROP COLUMN IF EXISTS source_provider" in sql
+
+
+def test_add_lineage_migration_logs_and_reraises_upgrade_errors(monkeypatch):
+    migration = import_module("app.migrations.add_lineage_to_vendor_metrics")
+    monkeypatch.setattr(migration, "engine", FailingEngine())
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        migration.upgrade()
+
+
+def test_add_lineage_migration_logs_and_reraises_downgrade_errors(monkeypatch):
+    migration = import_module("app.migrations.add_lineage_to_vendor_metrics")
+    monkeypatch.setattr(migration, "engine", FailingEngine())
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        migration.downgrade()

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -1,5 +1,6 @@
 
 [pytest]
 addopts = -v --ignore-glob="*e2e.py"
+pythonpath = .
 python_files = test_*.py
 testpaths = app/tests


### PR DESCRIPTION
## Summary

- Add nullable monthly cost lineage columns to `vendor_metrics` with additive migration wiring and fresh-table DDL.
- Persist Q-001 normalized provider, source period start/end, and nullable provider currency on insert and refresh updates.
- Return lineage metadata additively from the vendor-metrics API while keeping existing `month` and `cost` fields.
- Add service, route, and migration checks for lineage persistence, historical unknown lineage, uniqueness, and user/config scoping.

## Validation

- `uv run --extra dev black .`
- `uv run --extra dev black --check .`
- `uv run --extra dev flake8`
- `uv run --extra dev pytest -q`