### PR TITLE
Record vendor metric ingestion runs

### DIFF
--- a/api/app/migrations/__init__.py
+++ b/api/app/migrations/__init__.py
@@ -10,6 +10,9 @@ from .add_updated_at_to_vendor_metrics import (
     upgrade as add_updated_at_to_vendor_metrics,
 )
 from .add_lineage_to_vendor_metrics import upgrade as add_lineage_to_vendor_metrics
+from .create_vendor_metric_ingestion_runs_table import (
+    upgrade as create_vendor_metric_ingestion_runs_table,
+)
 
 # List of migrations in order of execution
 MIGRATIONS = [
@@ -21,4 +24,5 @@ MIGRATIONS = [
     create_vendor_metrics_table,  # Add vendor metrics table
     add_updated_at_to_vendor_metrics,  # Add the new migration
     add_lineage_to_vendor_metrics,
+    create_vendor_metric_ingestion_runs_table,
 ]

--- a/api/app/migrations/create_vendor_metric_ingestion_runs_table.py
+++ b/api/app/migrations/create_vendor_metric_ingestion_runs_table.py
@@ -1,0 +1,88 @@
+import logging
+from sqlalchemy import text
+from app.helpers.database import engine
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def upgrade():
+    logger.info("Starting migration: Creating vendor metric ingestion runs table")
+
+    try:
+        with engine.begin() as conn:
+            logger.info("Creating vendor_metric_ingestion_runs table...")
+            conn.execute(
+                text(
+                    """
+                    CREATE TABLE IF NOT EXISTS vendor_metric_ingestion_runs (
+                        id SERIAL PRIMARY KEY,
+                        user_id INTEGER NOT NULL REFERENCES users(id),
+                        vendor VARCHAR NOT NULL,
+                        identifier VARCHAR NOT NULL,
+                        started_at TIMESTAMP WITH TIME ZONE NOT NULL
+                            DEFAULT CURRENT_TIMESTAMP,
+                        completed_at TIMESTAMP WITH TIME ZONE NULL,
+                        requested_period_start DATE NULL,
+                        requested_period_end DATE NULL,
+                        source_period_start DATE NULL,
+                        source_period_end DATE NULL,
+                        status VARCHAR NOT NULL DEFAULT 'running',
+                        records_received INTEGER NOT NULL DEFAULT 0,
+                        records_stored INTEGER NOT NULL DEFAULT 0,
+                        error_category VARCHAR NULL,
+                        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                        CONSTRAINT ck_vendor_metric_ingestion_runs_status
+                            CHECK (status IN (
+                                'running', 'success', 'partial', 'failed'
+                            )),
+                        CONSTRAINT ck_vendor_metric_ingestion_runs_error_category
+                            CHECK (
+                                error_category IS NULL OR error_category IN (
+                                    'provider_error',
+                                    'row_validation',
+                                    'storage_error',
+                                    'configuration_error',
+                                    'incomplete_source'
+                                )
+                            )
+                    )
+                    """
+                )
+            )
+
+            conn.execute(
+                text(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_vendor_metric_ingestion_runs_user_id
+                    ON vendor_metric_ingestion_runs(user_id);
+                    CREATE INDEX IF NOT EXISTS idx_vendor_metric_ingestion_runs_vendor
+                    ON vendor_metric_ingestion_runs(vendor);
+                    CREATE INDEX IF NOT EXISTS idx_vendor_metric_ingestion_runs_scope_started
+                    ON vendor_metric_ingestion_runs(
+                        user_id, vendor, identifier, started_at
+                    );
+                    """
+                )
+            )
+
+            logger.info("Vendor metric ingestion runs table created successfully")
+    except Exception as e:
+        logger.error(f"Migration failed: {str(e)}")
+        raise
+
+
+def downgrade():
+    logger.info("Starting downgrade: Dropping vendor metric ingestion runs table")
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("DROP TABLE IF EXISTS vendor_metric_ingestion_runs"))
+            logger.info("Vendor metric ingestion runs table dropped successfully")
+    except Exception as e:
+        logger.error(f"Downgrade failed: {str(e)}")
+        raise
+
+
+if __name__ == "__main__":
+    upgrade()

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -6,6 +6,20 @@ import sqlalchemy
 
 Base = declarative_base()
 
+INGESTION_RUN_RUNNING_STATUS = "running"
+INGESTION_RUN_TERMINAL_STATUSES = ("success", "partial", "failed")
+INGESTION_RUN_STATUSES = (
+    INGESTION_RUN_RUNNING_STATUS,
+    *INGESTION_RUN_TERMINAL_STATUSES,
+)
+INGESTION_RUN_ERROR_CATEGORIES = (
+    "provider_error",
+    "row_validation",
+    "storage_error",
+    "configuration_error",
+    "incomplete_source",
+)
+
 
 class User(Base):
     __tablename__ = "users"
@@ -22,6 +36,9 @@ class User(Base):
         "HerokuAPIConfiguration", back_populates="user"
     )
     budget_plans = relationship("BudgetPlan", back_populates="user")
+    metric_ingestion_runs = relationship(
+        "VendorMetricIngestionRun", back_populates="user"
+    )
 
 
 class APIConfiguration(Base):
@@ -125,3 +142,77 @@ class VendorMetrics(Base):
             name="uq_vendor_metrics_user_vendor_identifier_month",
         ),
     )
+
+
+class VendorMetricIngestionRun(Base):
+    __tablename__ = "vendor_metric_ingestion_runs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    vendor = Column(String, nullable=False, index=True)
+    identifier = Column(String, nullable=False, index=True)
+    started_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    completed_at = Column(DateTime, nullable=True)
+    requested_period_start = Column(Date, nullable=True)
+    requested_period_end = Column(Date, nullable=True)
+    source_period_start = Column(Date, nullable=True)
+    source_period_end = Column(Date, nullable=True)
+    status = Column(
+        String, default=INGESTION_RUN_RUNNING_STATUS, nullable=False, index=True
+    )
+    records_received = Column(Integer, default=0, nullable=False)
+    records_stored = Column(Integer, default=0, nullable=False)
+    error_category = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    user = relationship("User", back_populates="metric_ingestion_runs")
+
+    __table_args__ = (
+        sqlalchemy.CheckConstraint(
+            "status IN ('running', 'success', 'partial', 'failed')",
+            name="ck_vendor_metric_ingestion_runs_status",
+        ),
+        sqlalchemy.CheckConstraint(
+            "error_category IS NULL OR error_category IN "
+            "('provider_error', 'row_validation', 'storage_error', "
+            "'configuration_error', 'incomplete_source')",
+            name="ck_vendor_metric_ingestion_runs_error_category",
+        ),
+        sqlalchemy.Index(
+            "idx_vendor_metric_ingestion_runs_scope_started",
+            "user_id",
+            "vendor",
+            "identifier",
+            "started_at",
+        ),
+    )
+
+    def complete(
+        self,
+        *,
+        status: str,
+        completed_at: datetime,
+        records_received: int = 0,
+        records_stored: int = 0,
+        source_period_start=None,
+        source_period_end=None,
+        error_category: str | None = None,
+    ):
+        if self.status != INGESTION_RUN_RUNNING_STATUS:
+            raise ValueError("Only running ingestion runs can be completed")
+        if status not in INGESTION_RUN_TERMINAL_STATUSES:
+            raise ValueError(f"Invalid terminal ingestion status: {status}")
+        if error_category and error_category not in INGESTION_RUN_ERROR_CATEGORIES:
+            raise ValueError(f"Invalid ingestion error category: {error_category}")
+        if records_received < 0 or records_stored < 0:
+            raise ValueError("Ingestion record counts cannot be negative")
+
+        self.status = status
+        self.completed_at = completed_at
+        self.records_received = records_received
+        self.records_stored = records_stored
+        self.source_period_start = source_period_start
+        self.source_period_end = source_period_end
+        self.error_category = error_category
+        self.updated_at = completed_at

--- a/api/app/services/vendor_metrics_service.py
+++ b/api/app/services/vendor_metrics_service.py
@@ -2,17 +2,20 @@ from sqlalchemy.orm import Session
 from sqlalchemy import and_
 from app.models import (
     VendorMetrics,
+    VendorMetricIngestionRun,
     User,
     DatadogAPIConfiguration,
     AWSAPIConfiguration,
     HerokuAPIConfiguration,
+    INGESTION_RUN_RUNNING_STATUS,
 )
 from app.services.aws_service import AWSService
 from app.services.datadog_service import DatadogService
 from app.services.heroku_service import HerokuService
 from app.services.monthly_costs import parse_iso_date, validate_monthly_cost_record
-from typing import List, Dict
-from datetime import datetime, timedelta
+from dataclasses import dataclass
+from typing import Any, List, Dict
+from datetime import date, datetime, timedelta
 import inspect
 import logging
 import os
@@ -31,6 +34,16 @@ FRESHNESS_STALE_HOURS = int(os.getenv("METRIC_FRESHNESS_STALE_HOURS", "48"))
 
 class VendorConfigurationNotFound(Exception):
     pass
+
+
+@dataclass
+class StoreMetricsResult:
+    records_received: int
+    records_stored: int
+    invalid_records: int
+    returned_months: set[str]
+    source_period_start: date | None
+    source_period_end: date | None
 
 
 def _iso_utc(dt: datetime | None) -> str | None:
@@ -59,6 +72,19 @@ def _serialize_metric(metric: VendorMetrics):
         "source_period_end": _date_iso(metric.source_period_end),
         "provider_currency": metric.provider_currency,
     }
+
+
+def _month_start(month: str) -> date:
+    return datetime.strptime(month, "%m-%Y").date().replace(day=1)
+
+
+def _month_after(month: str) -> date:
+    start = _month_start(month)
+    return (start.replace(day=1) + timedelta(days=32)).replace(day=1)
+
+
+def _month_sort_key(month: str) -> datetime:
+    return datetime.strptime(month, "%m-%Y")
 
 
 class VendorMetricsService:
@@ -126,20 +152,7 @@ class VendorMetricsService:
             if vendor not in SUPPORTED_VENDORS:
                 raise ValueError(f"Unsupported vendor: {vendor}")
 
-            # Get stored metrics
-            stored_metrics = (
-                self.db.query(VendorMetrics)
-                .filter(
-                    and_(
-                        VendorMetrics.user_id == self.user_id,
-                        VendorMetrics.vendor == vendor,
-                        VendorMetrics.identifier == identifier,
-                    )
-                )
-                .order_by(VendorMetrics.month)
-                .all()
-            )
-
+            stored_metrics = self._get_stored_metrics(vendor, identifier)
             had_cache = len(stored_metrics) > 0
 
             # Calculate date range for last 11 months
@@ -171,32 +184,32 @@ class VendorMetricsService:
                 # If current month data is older than 1 day, add it to missing months
                 missing_months.add(current_month)
 
-            # Track the outcome of the refresh attempt so cached, partial, or
-            # failed source data can never look silently current downstream.
-            attempt_status = "success"
-
             if missing_months:
+                # Get costs for missing months
+                earliest_missing = min(missing_months, key=_month_sort_key)
+                latest_missing = max(missing_months, key=_month_sort_key)
+
+                # If current month needs refresh, also get previous month to
+                # ensure complete data
+                if current_month in missing_months:
+                    earliest_date = datetime.strptime(earliest_missing, "%m-%Y")
+
+                    if (earliest_date - start_date).days > 0:
+                        earliest_missing = (
+                            earliest_date - timedelta(days=32)
+                        ).strftime("%m-%Y")
+                    else:
+                        earliest_missing = earliest_date.strftime("%m-%Y")
+
+                run = self._start_ingestion_run(
+                    vendor,
+                    identifier,
+                    requested_period_start=_month_start(earliest_missing),
+                    requested_period_end=_month_after(latest_missing),
+                )
+
+                costs = None
                 try:
-                    # Get costs for missing months
-                    earliest_missing = min(
-                        missing_months, key=lambda x: datetime.strptime(x, "%m-%Y")
-                    )
-                    latest_missing = max(
-                        missing_months, key=lambda x: datetime.strptime(x, "%m-%Y")
-                    )
-
-                    # If current month needs refresh, also get previous month to
-                    # ensure complete data
-                    if current_month in missing_months:
-                        earliest_date = datetime.strptime(earliest_missing, "%m-%Y")
-
-                        if (earliest_date - start_date).days > 0:
-                            earliest_missing = (
-                                earliest_date - timedelta(days=32)
-                            ).strftime("%m-%Y")
-                        else:
-                            earliest_missing = earliest_date.strftime("%m-%Y")
-
                     costs = self._get_vendor_costs(
                         vendor,
                         identifier,
@@ -205,71 +218,100 @@ class VendorMetricsService:
                     )
                     if inspect.isawaitable(costs):
                         costs = await costs
-
-                    # Store new metrics
-                    self._store_metrics(vendor, identifier, costs["data"])
-
-                    # If we asked to refresh the latest month but the vendor did
-                    # not return it, the refresh only partially succeeded.
-                    returned_months = {c["month"] for c in costs.get("data", [])}
-                    if (
-                        current_month in missing_months
-                        and current_month not in returned_months
-                    ):
-                        attempt_status = "partial"
-                except Exception as refresh_error:
+                except VendorConfigurationNotFound:
+                    self._complete_ingestion_run(
+                        run,
+                        status="failed",
+                        error_category="configuration_error",
+                    )
+                    raise
+                except Exception as provider_error:
+                    self._complete_ingestion_run(
+                        run,
+                        status="failed",
+                        error_category="provider_error",
+                    )
                     if not had_cache:
                         # No cached data to fall back to; surface the failure.
                         raise
-                    # Serve cached metrics, but mark the latest attempt as failed
-                    # so the dashboard can label the data as stale/cached.
+                    # Serve cached metrics, but leave the failed attempt
+                    # persisted so future reads keep showing cached/stale data.
                     logger.warning(
                         "Refresh for %s/%s failed; serving cached metrics: %s",
                         vendor,
                         identifier,
-                        refresh_error,
+                        provider_error,
                     )
-                    attempt_status = "failed"
+                else:
+                    cost_data = []
+                    try:
+                        cost_data = self._extract_cost_data(costs)
+                        store_result = self._store_metrics(
+                            vendor, identifier, cost_data
+                        )
+                    except ValueError as row_error:
+                        self._complete_ingestion_run(
+                            run,
+                            status="failed",
+                            error_category="row_validation",
+                        )
+                        if not had_cache:
+                            raise Exception(
+                                "Vendor cost response failed validation"
+                            ) from row_error
+                        logger.warning(
+                            "Refresh for %s/%s returned malformed rows; "
+                            "serving cached metrics: %s",
+                            vendor,
+                            identifier,
+                            row_error,
+                        )
+                    except Exception as storage_error:
+                        self._complete_ingestion_run(
+                            run,
+                            status="failed",
+                            records_received=len(cost_data),
+                            error_category="storage_error",
+                        )
+                        if not had_cache:
+                            raise
+                        logger.warning(
+                            "Refresh for %s/%s could not store metrics; "
+                            "serving cached metrics: %s",
+                            vendor,
+                            identifier,
+                            storage_error,
+                        )
+                    else:
+                        attempt_status = "success"
+                        error_category = None
 
-            # Return all metrics (stored + new)
-            all_metrics = (
-                self.db.query(VendorMetrics)
-                .filter(
-                    and_(
-                        VendorMetrics.user_id == self.user_id,
-                        VendorMetrics.vendor == vendor,
-                        VendorMetrics.identifier == identifier,
-                    )
-                )
-                .order_by(VendorMetrics.month)
-                .all()
-            )
+                        # If any individual rows were invalid, valid rows still
+                        # landed but the source refresh is auditable as partial.
+                        if store_result.invalid_records:
+                            attempt_status = "partial"
+                            error_category = "row_validation"
 
-            data = [
-                _serialize_metric(metric)
-                for metric in all_metrics
-                if datetime.strptime(metric.month, "%m-%Y").year
-                > datetime.now().year - 2
-            ]
+                        # If we asked to refresh the latest month but the vendor
+                        # did not return it, the refresh only partially succeeded.
+                        if (
+                            current_month in missing_months
+                            and current_month not in store_result.returned_months
+                        ):
+                            attempt_status = "partial"
+                            error_category = error_category or "incomplete_source"
 
-            # Freshness derived from stored write timestamps. Missing data stays
-            # absent (never zero-filled) so a gap cannot read as $0 spend.
-            last_success_at = max((m.updated_at for m in all_metrics), default=None)
-            data_through = (
-                max(data, key=lambda d: datetime.strptime(d["month"], "%m-%Y"))["month"]
-                if data
-                else None
-            )
+                        self._complete_ingestion_run(
+                            run,
+                            status=attempt_status,
+                            records_received=store_result.records_received,
+                            records_stored=store_result.records_stored,
+                            source_period_start=store_result.source_period_start,
+                            source_period_end=store_result.source_period_end,
+                            error_category=error_category,
+                        )
 
-            return {
-                "data": data,
-                "last_success_at": _iso_utc(last_success_at),
-                "last_attempt_at": _iso_utc(datetime.utcnow()),
-                "last_attempt_status": attempt_status,
-                "data_through": data_through,
-                "record_count": len(data),
-                "stale_after_hours": FRESHNESS_STALE_HOURS,
-            }
+            return self._build_metrics_response(vendor, identifier)
 
         except (ValueError, VendorConfigurationNotFound):
             raise
@@ -319,16 +361,167 @@ class VendorMetricsService:
                 f"for this user with identifier {identifier}"
             )
 
+    def _get_stored_metrics(self, vendor: str, identifier: str):
+        return (
+            self.db.query(VendorMetrics)
+            .filter(
+                and_(
+                    VendorMetrics.user_id == self.user_id,
+                    VendorMetrics.vendor == vendor,
+                    VendorMetrics.identifier == identifier,
+                )
+            )
+            .order_by(VendorMetrics.month)
+            .all()
+        )
+
+    def _start_ingestion_run(
+        self,
+        vendor: str,
+        identifier: str,
+        *,
+        requested_period_start: date | None = None,
+        requested_period_end: date | None = None,
+    ) -> VendorMetricIngestionRun:
+        run = VendorMetricIngestionRun(
+            user_id=self.user_id,
+            vendor=vendor,
+            identifier=identifier,
+            started_at=datetime.utcnow(),
+            requested_period_start=requested_period_start,
+            requested_period_end=requested_period_end,
+            status=INGESTION_RUN_RUNNING_STATUS,
+        )
+        self.db.add(run)
+        self.db.commit()
+        self.db.refresh(run)
+        return run
+
+    def _complete_ingestion_run(
+        self,
+        run: VendorMetricIngestionRun,
+        *,
+        status: str,
+        records_received: int = 0,
+        records_stored: int = 0,
+        source_period_start: date | None = None,
+        source_period_end: date | None = None,
+        error_category: str | None = None,
+    ):
+        try:
+            run.complete(
+                status=status,
+                completed_at=datetime.utcnow(),
+                records_received=records_received,
+                records_stored=records_stored,
+                source_period_start=source_period_start,
+                source_period_end=source_period_end,
+                error_category=error_category,
+            )
+            self.db.add(run)
+            self.db.commit()
+            self.db.refresh(run)
+        except Exception:
+            self.db.rollback()
+            raise
+
+    def _extract_cost_data(self, costs: Any) -> list:
+        if not isinstance(costs, dict):
+            raise ValueError("Vendor cost response must be a mapping")
+
+        cost_data = costs.get("data", [])
+        if cost_data is None:
+            return []
+        if not isinstance(cost_data, list):
+            raise ValueError("Vendor cost response data must be a list")
+        return cost_data
+
+    def _latest_ingestion_run(
+        self, vendor: str, identifier: str, status: str | None = None
+    ) -> VendorMetricIngestionRun | None:
+        query = self.db.query(VendorMetricIngestionRun).filter(
+            and_(
+                VendorMetricIngestionRun.user_id == self.user_id,
+                VendorMetricIngestionRun.vendor == vendor,
+                VendorMetricIngestionRun.identifier == identifier,
+            )
+        )
+        if status:
+            query = query.filter(VendorMetricIngestionRun.status == status)
+        return query.order_by(
+            VendorMetricIngestionRun.started_at.desc(),
+            VendorMetricIngestionRun.id.desc(),
+        ).first()
+
+    def _build_metrics_response(self, vendor: str, identifier: str):
+        all_metrics = self._get_stored_metrics(vendor, identifier)
+
+        data = [
+            _serialize_metric(metric)
+            for metric in all_metrics
+            if datetime.strptime(metric.month, "%m-%Y").year > datetime.now().year - 2
+        ]
+
+        latest_attempt = self._latest_ingestion_run(vendor, identifier)
+        latest_success = self._latest_ingestion_run(vendor, identifier, "success")
+        last_attempt_status = (
+            latest_attempt.status
+            if latest_attempt and latest_attempt.status != INGESTION_RUN_RUNNING_STATUS
+            else None
+        )
+        last_attempt_at = (
+            latest_attempt.completed_at or latest_attempt.started_at
+            if latest_attempt
+            else None
+        )
+        last_success_at = latest_success.completed_at if latest_success else None
+        data_through = (
+            max(data, key=lambda d: datetime.strptime(d["month"], "%m-%Y"))["month"]
+            if data
+            else None
+        )
+
+        return {
+            "data": data,
+            "last_success_at": _iso_utc(last_success_at),
+            "last_attempt_at": _iso_utc(last_attempt_at),
+            "last_attempt_status": last_attempt_status,
+            "data_through": data_through,
+            "record_count": len(data),
+            "stale_after_hours": FRESHNESS_STALE_HOURS,
+        }
+
     def _store_metrics(self, vendor: str, identifier: str, cost_data: list):
         """Store metrics in the database"""
+        records_stored = 0
+        invalid_records = 0
+        returned_months: set[str] = set()
+        source_period_starts: list[date] = []
+        source_period_ends: list[date] = []
+
         for cost_item in cost_data:
-            cost_record = validate_monthly_cost_record(
-                cost_item, expected_provider=vendor.lower()
-            )
-            source_period_start = parse_iso_date(
-                cost_record["period_start"], "period_start"
-            )
-            source_period_end = parse_iso_date(cost_record["period_end"], "period_end")
+            try:
+                cost_record = validate_monthly_cost_record(
+                    cost_item, expected_provider=vendor.lower()
+                )
+                source_period_start = parse_iso_date(
+                    cost_record["period_start"], "period_start"
+                )
+                source_period_end = parse_iso_date(
+                    cost_record["period_end"], "period_end"
+                )
+            except ValueError as exc:
+                invalid_records += 1
+                logger.warning(
+                    "Skipping malformed %s monthly cost row for user %s, "
+                    "config %s: %s",
+                    vendor,
+                    self.user_id,
+                    identifier,
+                    exc,
+                )
+                continue
+
             # Check if metric already exists
             existing_metric = (
                 self.db.query(VendorMetrics)
@@ -365,4 +558,24 @@ class VendorMetricsService:
                 )
                 self.db.add(metric)
 
-        self.db.commit()
+            records_stored += 1
+            returned_months.add(cost_record["month"])
+            source_period_starts.append(source_period_start)
+            source_period_ends.append(source_period_end)
+
+        try:
+            self.db.commit()
+        except Exception:
+            self.db.rollback()
+            raise
+
+        return StoreMetricsResult(
+            records_received=len(cost_data),
+            records_stored=records_stored,
+            invalid_records=invalid_records,
+            returned_months=returned_months,
+            source_period_start=(
+                min(source_period_starts) if source_period_starts else None
+            ),
+            source_period_end=max(source_period_ends) if source_period_ends else None,
+        )

--- a/api/app/tests/services/test_vendor_metrics_service.py
+++ b/api/app/tests/services/test_vendor_metrics_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 import pytest
@@ -12,6 +12,7 @@ from app.models import (
     DatadogAPIConfiguration,
     HerokuAPIConfiguration,
     User,
+    VendorMetricIngestionRun,
     VendorMetrics,
 )
 from app.services.monthly_costs import build_monthly_cost_record
@@ -48,6 +49,58 @@ def shift_month(date: datetime, months: int) -> datetime:
     year = date.year + month_index // 12
     month = month_index % 12 + 1
     return date.replace(year=year, month=month, day=1)
+
+
+def required_months_for_service():
+    end_date = datetime.now()
+    start_date = end_date - timedelta(days=365)
+    current_date = start_date
+    months = []
+    while current_date <= end_date:
+        months.append(current_date.strftime("%m-%Y"))
+        current_date = (current_date.replace(day=1) + timedelta(days=32)).replace(day=1)
+    return months
+
+
+def add_successful_ingestion_run(
+    db_session,
+    user,
+    vendor="aws",
+    identifier="test-config",
+    completed_at=None,
+):
+    completed_at = completed_at or datetime.utcnow()
+    run = VendorMetricIngestionRun(
+        user_id=user.id,
+        vendor=vendor,
+        identifier=identifier,
+        started_at=completed_at - timedelta(minutes=1),
+        completed_at=completed_at,
+        requested_period_start=completed_at.date().replace(day=1),
+        requested_period_end=shift_month(completed_at, 1).date(),
+        source_period_start=completed_at.date().replace(day=1),
+        source_period_end=shift_month(completed_at, 1).date(),
+        status="success",
+        records_received=1,
+        records_stored=1,
+    )
+    db_session.add(run)
+    db_session.commit()
+    return run
+
+
+def seed_required_metrics(db_session, user, vendor="aws", identifier="test-config"):
+    for index, month in enumerate(required_months_for_service()):
+        db_session.add(
+            VendorMetrics(
+                user_id=user.id,
+                vendor=vendor,
+                identifier=identifier,
+                month=month,
+                cost=100 + index,
+            )
+        )
+    db_session.commit()
 
 
 @pytest.fixture
@@ -121,6 +174,39 @@ def add_heroku_config(db_session, user, identifier="test-config"):
     return config
 
 
+def test_ingestion_run_complete_validates_terminal_transition(user):
+    run = VendorMetricIngestionRun(
+        user_id=user.id,
+        vendor="aws",
+        identifier="test-config",
+        status="running",
+    )
+
+    run.complete(
+        status="success",
+        completed_at=datetime.utcnow(),
+        records_received=2,
+        records_stored=2,
+    )
+
+    assert run.status == "success"
+    assert run.completed_at is not None
+    with pytest.raises(ValueError, match="Only running ingestion runs"):
+        run.complete(status="failed", completed_at=datetime.utcnow())
+
+
+def test_ingestion_run_rejects_unknown_status(user):
+    run = VendorMetricIngestionRun(
+        user_id=user.id,
+        vendor="aws",
+        identifier="test-config",
+        status="running",
+    )
+
+    with pytest.raises(ValueError, match="Invalid terminal ingestion status"):
+        run.complete(status="greenish", completed_at=datetime.utcnow())
+
+
 class TestVendorMetricsService:
     @pytest.mark.asyncio
     async def test_get_and_store_vendor_metrics_aws_success(
@@ -142,6 +228,17 @@ class TestVendorMetricsService:
 
         assert metrics_by_month(result) == metrics_by_month(mock_costs_response)
         assert db_session.query(VendorMetrics).count() == 2
+        run = db_session.query(VendorMetricIngestionRun).one()
+        assert run.user_id == user.id
+        assert run.vendor == "aws"
+        assert run.identifier == "test-config"
+        assert run.status == "success"
+        assert run.completed_at is not None
+        assert run.requested_period_start is not None
+        assert run.requested_period_end is not None
+        assert run.records_received == 2
+        assert run.records_stored == 2
+        assert run.error_category is None
         stored_metric = (
             db_session.query(VendorMetrics)
             .filter(VendorMetrics.month == mock_costs_response["data"][0]["month"])
@@ -170,6 +267,20 @@ class TestVendorMetricsService:
             == mock_costs_response["data"][0]["period_end"]
         )
         assert result_metric["provider_currency"] == "USD"
+        assert (
+            run.source_period_start.isoformat()
+            == mock_costs_response["data"][0]["period_start"]
+        )
+        assert (
+            run.source_period_end.isoformat()
+            == mock_costs_response["data"][1]["period_end"]
+        )
+        assert (
+            result["last_success_at"]
+            == run.completed_at.replace(microsecond=0).isoformat() + "Z"
+        )
+        assert result["last_attempt_at"] == result["last_success_at"]
+        assert result["last_attempt_status"] == "success"
         mock_aws_instance.get_monthly_costs.assert_called_once()
 
     @pytest.mark.asyncio
@@ -356,6 +467,11 @@ class TestVendorMetricsService:
         previous_month = shift_month(datetime.now().replace(day=1), -1).strftime(
             "%m-%Y"
         )
+        prior_success = add_successful_ingestion_run(
+            db_session,
+            user,
+            completed_at=datetime.utcnow() - timedelta(hours=2),
+        )
         db_session.add(
             VendorMetrics(
                 user_id=user.id,
@@ -374,7 +490,9 @@ class TestVendorMetricsService:
             autospec=True,
         ) as mock_aws_service:
             mock_aws_instance = Mock()
-            mock_aws_instance.get_monthly_costs.side_effect = Exception("vendor down")
+            mock_aws_instance.get_monthly_costs.side_effect = Exception(
+                "vendor down sentinel-secret-token"
+            )
             mock_aws_service.return_value = mock_aws_instance
 
             # Must not raise: cached data is served with a failed-attempt label.
@@ -383,7 +501,18 @@ class TestVendorMetricsService:
         assert result["last_attempt_status"] == "failed"
         assert result["record_count"] == 1
         assert metrics_by_month(result) == {previous_month: 42.0}
-        assert result["last_success_at"] is not None
+        assert (
+            result["last_success_at"]
+            == prior_success.completed_at.replace(microsecond=0).isoformat() + "Z"
+        )
+        runs = (
+            db_session.query(VendorMetricIngestionRun)
+            .order_by(VendorMetricIngestionRun.started_at)
+            .all()
+        )
+        assert [run.status for run in runs] == ["success", "failed"]
+        assert runs[-1].error_category == "provider_error"
+        assert "sentinel-secret-token" not in (runs[-1].error_category or "")
 
     @pytest.mark.asyncio
     async def test_failed_refresh_without_cache_raises(self, db_session, user):
@@ -395,12 +524,78 @@ class TestVendorMetricsService:
             autospec=True,
         ) as mock_aws_service:
             mock_aws_instance = Mock()
-            mock_aws_instance.get_monthly_costs.side_effect = Exception("vendor down")
+            mock_aws_instance.get_monthly_costs.side_effect = Exception(
+                "vendor down sentinel-secret-token"
+            )
             mock_aws_service.return_value = mock_aws_instance
 
             # No cached data to fall back to: the failure must surface.
             with pytest.raises(Exception, match="Failed to get and store aws metrics"):
                 await service.get_and_store_vendor_metrics("aws", "test-config")
+
+        run = db_session.query(VendorMetricIngestionRun).one()
+        assert run.status == "failed"
+        assert run.completed_at is not None
+        assert run.records_received == 0
+        assert run.records_stored == 0
+        assert run.error_category == "provider_error"
+        assert "sentinel-secret-token" not in (run.error_category or "")
+
+    @pytest.mark.asyncio
+    async def test_storage_failure_completes_failed_run_and_preserves_cache(
+        self, db_session, user, cost_response_for
+    ):
+        add_aws_config(db_session, user)
+        previous_month = shift_month(datetime.now().replace(day=1), -1).strftime(
+            "%m-%Y"
+        )
+        prior_success = add_successful_ingestion_run(
+            db_session,
+            user,
+            completed_at=datetime.utcnow() - timedelta(hours=2),
+        )
+        db_session.add(
+            VendorMetrics(
+                user_id=user.id,
+                vendor="aws",
+                identifier="test-config",
+                month=previous_month,
+                cost=42.0,
+            )
+        )
+        db_session.commit()
+
+        service = VendorMetricsService(user.id, db_session)
+
+        with patch(
+            "app.services.vendor_metrics_service.AWSService",
+            autospec=True,
+        ) as mock_aws_service, patch.object(
+            service,
+            "_store_metrics",
+            side_effect=Exception("database wrote sentinel-secret-token"),
+        ):
+            mock_aws_instance = Mock()
+            mock_aws_instance.get_monthly_costs.return_value = cost_response_for("aws")
+            mock_aws_service.return_value = mock_aws_instance
+
+            result = await service.get_and_store_vendor_metrics("aws", "test-config")
+
+        assert result["last_attempt_status"] == "failed"
+        assert (
+            result["last_success_at"]
+            == prior_success.completed_at.replace(microsecond=0).isoformat() + "Z"
+        )
+        assert metrics_by_month(result) == {previous_month: 42.0}
+        failed_run = (
+            db_session.query(VendorMetricIngestionRun)
+            .filter(VendorMetricIngestionRun.status == "failed")
+            .one()
+        )
+        assert failed_run.records_received == 2
+        assert failed_run.records_stored == 0
+        assert failed_run.error_category == "storage_error"
+        assert "sentinel-secret-token" not in (failed_run.error_category or "")
 
     @pytest.mark.asyncio
     async def test_partial_refresh_when_current_month_missing(self, db_session, user):
@@ -442,6 +637,62 @@ class TestVendorMetricsService:
             result = await service.get_and_store_vendor_metrics("aws", "test-config")
 
         assert result["last_attempt_status"] == "partial"
+        run = db_session.query(VendorMetricIngestionRun).one()
+        assert run.status == "partial"
+        assert run.records_received == 1
+        assert run.records_stored == 1
+        assert run.error_category == "incomplete_source"
+
+    @pytest.mark.asyncio
+    async def test_partial_refresh_records_row_validation_failure(
+        self, db_session, user
+    ):
+        add_aws_config(db_session, user)
+        previous_month_date = shift_month(datetime.now().replace(day=1), -1)
+        current_month_date = datetime.now().replace(day=1)
+        service = VendorMetricsService(user.id, db_session)
+
+        with patch(
+            "app.services.vendor_metrics_service.AWSService",
+            autospec=True,
+        ) as mock_aws_service:
+            mock_aws_instance = Mock()
+            mock_aws_instance.get_monthly_costs.return_value = {
+                "data": [
+                    build_monthly_cost_record(
+                        provider="aws",
+                        period_start=previous_month_date.date(),
+                        period_end=shift_month(previous_month_date, 1).date(),
+                        cost=100.0,
+                        currency="USD",
+                    ),
+                    {
+                        "month": current_month_date.strftime("%m-%Y"),
+                        "cost": "not numeric",
+                        "provider": "aws",
+                        "period_start": current_month_date.date().isoformat(),
+                        "period_end": shift_month(current_month_date, 1)
+                        .date()
+                        .isoformat(),
+                        "currency": "USD",
+                    },
+                ]
+            }
+            mock_aws_service.return_value = mock_aws_instance
+
+            result = await service.get_and_store_vendor_metrics("aws", "test-config")
+
+        run = db_session.query(VendorMetricIngestionRun).one()
+        assert result["last_attempt_status"] == "partial"
+        assert metrics_by_month(result) == {
+            previous_month_date.strftime("%m-%Y"): 100.0
+        }
+        assert run.status == "partial"
+        assert run.records_received == 2
+        assert run.records_stored == 1
+        assert run.error_category == "row_validation"
+        assert run.source_period_start == previous_month_date.date()
+        assert run.source_period_end == shift_month(previous_month_date, 1).date()
 
     @pytest.mark.asyncio
     async def test_empty_source_reports_no_records(self, db_session, user):
@@ -463,6 +714,84 @@ class TestVendorMetricsService:
         assert result["data"] == []
         assert result["data_through"] is None
         assert result["last_success_at"] is None
+        assert result["last_attempt_status"] == "partial"
+        run = db_session.query(VendorMetricIngestionRun).one()
+        assert run.status == "partial"
+        assert run.records_received == 0
+        assert run.records_stored == 0
+        assert run.error_category == "incomplete_source"
+
+    @pytest.mark.asyncio
+    async def test_cached_read_recovers_persisted_runs_without_resetting_health(
+        self, db_session, user
+    ):
+        add_aws_config(db_session, user)
+        seed_required_metrics(db_session, user)
+        now = datetime.utcnow()
+        target_success = add_successful_ingestion_run(
+            db_session,
+            user,
+            completed_at=now - timedelta(hours=3),
+        )
+        target_failed = VendorMetricIngestionRun(
+            user_id=user.id,
+            vendor="aws",
+            identifier="test-config",
+            started_at=now - timedelta(hours=1),
+            completed_at=now - timedelta(minutes=59),
+            requested_period_start=now.date().replace(day=1),
+            requested_period_end=shift_month(now, 1).date(),
+            status="failed",
+            records_received=0,
+            records_stored=0,
+            error_category="provider_error",
+        )
+        db_session.add(target_failed)
+
+        other_user = User(sub="other-user")
+        db_session.add(other_user)
+        db_session.flush()
+        add_successful_ingestion_run(
+            db_session,
+            other_user,
+            completed_at=now,
+        )
+        add_successful_ingestion_run(
+            db_session,
+            user,
+            identifier="other-config",
+            completed_at=now,
+        )
+        db_session.commit()
+
+        new_service_instance = VendorMetricsService(user.id, db_session)
+
+        with patch(
+            "app.services.vendor_metrics_service.AWSService",
+            autospec=True,
+        ) as mock_aws_service:
+            result = await new_service_instance.get_and_store_vendor_metrics(
+                "aws", "test-config"
+            )
+
+        mock_aws_service.assert_not_called()
+        assert result["last_attempt_status"] == "failed"
+        assert (
+            result["last_attempt_at"]
+            == target_failed.completed_at.replace(microsecond=0).isoformat() + "Z"
+        )
+        assert (
+            result["last_success_at"]
+            == target_success.completed_at.replace(microsecond=0).isoformat() + "Z"
+        )
+        assert (
+            db_session.query(VendorMetricIngestionRun)
+            .filter(VendorMetricIngestionRun.user_id == user.id)
+            .filter(VendorMetricIngestionRun.vendor == "aws")
+            .filter(VendorMetricIngestionRun.identifier == "test-config")
+            .count()
+            == 2
+        )
 
     @pytest.mark.asyncio
     async def test_get_and_store_vendor_metrics_invalid_vendor(self, db_session, user):
@@ -513,6 +842,13 @@ class TestVendorMetricsService:
         assert any("AWS metrics updated" in msg for msg in results["success"])
         assert any("Datadog metrics updated" in msg for msg in results["success"])
         assert any("Heroku metrics updated" in msg for msg in results["success"])
+        runs = db_session.query(VendorMetricIngestionRun).all()
+        assert len(runs) == 3
+        assert {(run.vendor, run.identifier, run.status) for run in runs} == {
+            ("aws", "test-aws", "success"),
+            ("datadog", "test-datadog", "success"),
+            ("heroku", "test-heroku", "success"),
+        }
 
     @pytest.mark.asyncio
     async def test_batch_update_all_vendor_metrics_partial_failure(
@@ -559,3 +895,12 @@ class TestVendorMetricsService:
         assert any(
             "Failed to update Datadog metrics" in msg for msg in results["failed"]
         )
+        runs = db_session.query(VendorMetricIngestionRun).all()
+        assert len(runs) == 3
+        assert {(run.vendor, run.identifier, run.status) for run in runs} == {
+            ("aws", "test-aws", "success"),
+            ("datadog", "test-datadog", "failed"),
+            ("heroku", "test-heroku", "success"),
+        }
+        failed_run = next(run for run in runs if run.vendor == "datadog")
+        assert failed_run.error_category == "provider_error"

--- a/api/app/tests/test_vendor_metrics_migrations.py
+++ b/api/app/tests/test_vendor_metrics_migrations.py
@@ -64,7 +64,7 @@ def test_add_lineage_migration_is_additive_nullable_and_registered(monkeypatch):
     migration.upgrade()
 
     sql = captured_sql(fake_engine)
-    assert MIGRATIONS[-1] is migration.upgrade
+    assert migration.upgrade in MIGRATIONS
     assert "ADD COLUMN IF NOT EXISTS source_provider VARCHAR" in sql
     assert "ADD COLUMN IF NOT EXISTS source_period_start DATE" in sql
     assert "ADD COLUMN IF NOT EXISTS source_period_end DATE" in sql
@@ -100,3 +100,47 @@ def test_add_lineage_migration_logs_and_reraises_downgrade_errors(monkeypatch):
 
     with pytest.raises(RuntimeError, match="database unavailable"):
         migration.downgrade()
+
+
+def test_create_vendor_metric_ingestion_runs_table_registered(monkeypatch):
+    migration = import_module(
+        "app.migrations.create_vendor_metric_ingestion_runs_table"
+    )
+    fake_engine = FakeEngine()
+    monkeypatch.setattr(migration, "engine", fake_engine)
+
+    migration.upgrade()
+
+    sql = captured_sql(fake_engine)
+    assert MIGRATIONS[-1] is migration.upgrade
+    assert "CREATE TABLE IF NOT EXISTS vendor_metric_ingestion_runs" in sql
+    assert "user_id INTEGER NOT NULL REFERENCES users(id)" in sql
+    assert "vendor VARCHAR NOT NULL" in sql
+    assert "identifier VARCHAR NOT NULL" in sql
+    assert "requested_period_start DATE NULL" in sql
+    assert "requested_period_end DATE NULL" in sql
+    assert "source_period_start DATE NULL" in sql
+    assert "source_period_end DATE NULL" in sql
+    assert "status VARCHAR NOT NULL DEFAULT 'running'" in sql
+    assert "records_received INTEGER NOT NULL DEFAULT 0" in sql
+    assert "records_stored INTEGER NOT NULL DEFAULT 0" in sql
+    assert "error_category VARCHAR NULL" in sql
+    assert "'success', 'partial', 'failed'" in sql
+    assert "'provider_error'" in sql
+    assert "'row_validation'" in sql
+    assert "'incomplete_source'" in sql
+    assert "idx_vendor_metric_ingestion_runs_scope_started" in sql
+
+
+def test_create_vendor_metric_ingestion_runs_downgrade(monkeypatch):
+    migration = import_module(
+        "app.migrations.create_vendor_metric_ingestion_runs_table"
+    )
+    fake_engine = FakeEngine()
+    monkeypatch.setattr(migration, "engine", fake_engine)
+
+    migration.downgrade()
+
+    assert "DROP TABLE IF EXISTS vendor_metric_ingestion_runs" in captured_sql(
+        fake_engine
+    )


### PR DESCRIPTION
## What changed

- Added a persisted `vendor_metric_ingestion_runs` table and ORM model for vendor metrics refresh attempts.
- Recorded tenant/user scope, vendor, configuration identifier, requested/source windows, terminal status, row counts, and bounded error categories.
- Updated vendor metrics refresh responses to derive latest attempt and latest successful run from persisted history instead of request-local state or metric-row timestamps.
- Added service and migration tests for success, partial row validation, provider/storage failures, cross-request recovery, isolation, and batch attempts across AWS, Datadog, and Heroku.

## Why

Product Brain Q-003 needs durable ingestion evidence before source health can be trusted across later reads, process restarts, and batch refreshes. A cached metrics read should not silently reset health to success.

## Validation

- `cd api && uv run --extra dev pytest -q` (`39 passed`)
- `git diff --check`