### PR TITLE
Remove legacy admin sidebar chrome

### DIFF
--- a/dashboard/src/components/navbar/index.tsx
+++ b/dashboard/src/components/navbar/index.tsx
@@ -2,14 +2,10 @@ import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import routes from "routes";
 import { useAuth0 } from "@auth0/auth0-react";
-import { MdLogout, MdMenu } from "react-icons/md";
+import { MdLogout } from "react-icons/md";
 import InfraSpendLogo from "components/logo/InfraSpendLogo";
 
-interface NavbarProps {
-  onOpenSidenav: () => void;
-}
-
-const Navbar: React.FC<NavbarProps> = ({ onOpenSidenav }) => {
+const Navbar: React.FC = () => {
   const { logout } = useAuth0();
   const location = useLocation();
 
@@ -34,16 +30,8 @@ const Navbar: React.FC<NavbarProps> = ({ onOpenSidenav }) => {
       <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={onOpenSidenav}
-              className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-gray-200 text-navy-700 transition-colors hover:bg-gray-50 dark:border-white/10 dark:text-white dark:hover:bg-white/10 xl:hidden"
-              aria-label="Open navigation"
-            >
-              <MdMenu className="h-5 w-5" aria-hidden="true" />
-            </button>
             <InfraSpendLogo
-              className="h-8 w-auto text-navy-700 dark:text-white xl:hidden"
+              className="h-8 w-auto text-navy-700 dark:text-white"
               showWordmark={false}
             />
             <div>

--- a/dashboard/src/layouts/admin/index.tsx
+++ b/dashboard/src/layouts/admin/index.tsx
@@ -1,7 +1,5 @@
-import React, { useState } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import Navbar from "components/navbar";
-import Sidebar from "components/sidebar";
 import routes from "routes";
 
 // Helper function to generate routes
@@ -21,17 +19,14 @@ const getRoutes = (routes: any[]) => {
 };
 
 export default function Admin(props: { [x: string]: any }) {
-  const [open, setOpen] = useState(false);
-
   return (
-    <div className="flex h-full min-h-screen w-full bg-gray-50 dark:bg-navy-900">
-      <Sidebar open={open} onClose={() => setOpen(false)} />
+    <div className="min-h-screen w-full overflow-x-hidden bg-gray-50 dark:bg-navy-900">
       {/* Navbar & Main Content */}
       <div className="h-full w-full">
-        <main className={`mx-[12px] h-full flex-none transition-all md:pr-2`}>
+        <main className="mx-auto h-full max-w-[1680px] px-3 transition-all md:px-4">
           <div>
-            <Navbar onOpenSidenav={() => setOpen(true)} />
-            <div className="pt-5s mx-auto mb-auto min-h-[84vh] p-2 md:pr-2">
+            <Navbar />
+            <div className="mx-auto mb-auto min-h-[84vh] pb-4">
               <Routes>
                 {getRoutes(routes)}
                 <Route path="/" element={<Navigate to="/admin/default" replace />} />


### PR DESCRIPTION
## Summary

Removes the legacy admin sidebar from the authenticated dashboard layout now that navigation lives in the top bar.

## Why

The old off-canvas Horizon UI sidebar was still mounted alongside the current top navigation. On the admin pages it could bleed into the left edge of the viewport and show stale UI fragments, especially around the linked-accounts modal.

## Impact

- Admin pages now use the full viewport without the hidden sidebar layer.
- The navbar no longer exposes a hamburger button that opens dead legacy chrome.
- Existing Dashboard and Linked Accounts routes remain available through the top navigation.

## Validation

- `git diff --check`
- `npm run build`
- `npm test -- --watchAll=false --runInBand`