### PR TITLE
Redesign linked account setup

### DIFF
--- a/dashboard/src/views/admin/configuration/index.tsx
+++ b/dashboard/src/views/admin/configuration/index.tsx
@@ -3,19 +3,24 @@ import APIConfig from "../default/components/APIConfig";
 
 export default function Configuration() {
   useEffect(() => {
-    document.title = "Configuration";
+    document.title = "Linked Accounts";
   }, []);
 
   return (
-    <div className="mt-3">
-      <div className="mb-4">
-        <h1 className="text-2xl font-bold text-navy-700 dark:text-white">
-          Configuration
+    <div className="mx-auto mt-3 max-w-[1500px] space-y-6">
+      <div>
+        <p className="text-sm font-semibold uppercase text-brand-600 dark:text-teal-200">
+          Linked accounts
+        </p>
+        <h1 className="mt-2 text-3xl font-bold leading-tight text-navy-700 dark:text-white">
+          Linked cost sources
         </h1>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-gray-700 dark:text-gray-300">
+          Manage the read-only provider credentials that power InfraSpend cost
+          evidence, source freshness, forecasts, and budget planning.
+        </p>
       </div>
-      <div className="mt-5 grid grid-cols-1 gap-5">
-        <APIConfig />
-      </div>
+      <APIConfig />
     </div>
   );
 }

--- a/dashboard/src/views/admin/default/components/APIConfig.tsx
+++ b/dashboard/src/views/admin/default/components/APIConfig.tsx
@@ -1,16 +1,30 @@
-import Card from "components/card";
-import React, { useState } from "react";
-import { useAPIConfigurations } from "./hooks/useAPIConfigurations";
-import Modal from "components/modal";
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  MdAccountTree,
+  MdAddCircleOutline,
+  MdCheckCircle,
+  MdClose,
+  MdDashboard,
+  MdEdit,
+  MdErrorOutline,
+  MdKey,
+  MdOutlineSecurity,
+} from "react-icons/md";
 import DatadogConfig from "./DatadogConfig";
 import AWSConfig from "./AWSConfig";
 import HerokuConfig from "./HerokuConfig";
+import { useAPIConfigurations } from "./hooks/useAPIConfigurations";
 
 interface VendorConfig {
   id: string;
   name: string;
   type: string;
+  description: string;
+  credentials: string;
+  evidence: string;
   component: React.ComponentType<any>;
+  icon: JSX.Element;
 }
 
 const VENDOR_CONFIGS: VendorConfig[] = [
@@ -18,148 +32,372 @@ const VENDOR_CONFIGS: VendorConfig[] = [
     id: "datadog",
     name: "Datadog",
     type: "datadog",
+    description: "Observability spend and usage context.",
+    credentials: "API key and app key",
+    evidence: "Monthly costs, freshness, and forecast context",
     component: DatadogConfig,
+    icon: <MdOutlineSecurity className="h-6 w-6" aria-hidden="true" />,
   },
   {
     id: "aws",
     name: "AWS",
     type: "aws",
+    description: "Cloud billing source for infrastructure costs.",
+    credentials: "Access key ID and secret access key",
+    evidence: "Monthly spend, cached-state visibility, and forecasts",
     component: AWSConfig,
+    icon: <MdAccountTree className="h-6 w-6" aria-hidden="true" />,
   },
   {
     id: "heroku",
     name: "Heroku",
     type: "heroku",
+    description: "Platform invoices for personal or team accounts.",
+    credentials: "API key and optional team name",
+    evidence: "Invoice-backed costs, freshness, and budget planning",
     component: HerokuConfig,
+    icon: <MdKey className="h-6 w-6" aria-hidden="true" />,
   },
 ];
 
+interface SelectedSource {
+  vendor: VendorConfig;
+  config?: {
+    id: number;
+    type: string;
+    identifier: string;
+  };
+}
+
 const APIConfig = () => {
   const { configurations, loading, error, refresh } = useAPIConfigurations();
-  const [showConfigModal, setShowConfigModal] = useState(false);
-  const [selectedVendor, setSelectedVendor] = useState<VendorConfig | null>(null);
+  const [selectedSource, setSelectedSource] = useState<SelectedSource | null>(
+    null
+  );
 
-  const handleConfigureVendor = (vendor: VendorConfig) => {
-    setSelectedVendor(vendor);
-    setShowConfigModal(true);
-  };
+  useEffect(() => {
+    if (!selectedSource) return;
 
-  const handleCloseModal = () => {
-    setShowConfigModal(false);
-    setSelectedVendor(null);
-  };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setSelectedSource(null);
+      }
+    };
+
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
+  }, [selectedSource]);
 
   const getVendorByType = (type: string) => {
-    return VENDOR_CONFIGS.find(vendor => vendor.type === type);
+    return VENDOR_CONFIGS.find((vendor) => vendor.type === type);
   };
+
+  const getConfigurationsByType = (type: string) => {
+    return configurations.filter((config) => config.type === type);
+  };
+
+  const getDefaultIdentifier = (vendor: VendorConfig) => {
+    const vendorConfigurations = getConfigurationsByType(vendor.type);
+    return vendorConfigurations.length === 0
+      ? "Default Configuration"
+      : `${vendor.name} account ${vendorConfigurations.length + 1}`;
+  };
+
+  const linkedConfigurations = configurations
+    .map((config) => ({
+      config,
+      vendor: getVendorByType(config.type),
+    }))
+    .filter(
+      (
+        entry
+      ): entry is {
+        config: (typeof configurations)[number];
+        vendor: VendorConfig;
+      } => Boolean(entry.vendor)
+    );
+
+  const hasLinkedSources = linkedConfigurations.length > 0;
 
   return (
     <>
-      <Card extra="pb-6 p-[20px]">
-        <div className="flex flex-col">
-          <div className="flex justify-between items-center mb-6">
-            <h2 className="text-lg font-bold text-navy-700 dark:text-white">
-              Linked Accounts
+      <div className="space-y-6">
+        <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_340px]">
+          <div className="rounded-lg border border-gray-200/80 bg-white p-6 shadow-sm shadow-shadow-500 dark:border-white/10 dark:bg-navy-800 dark:shadow-none">
+            <p className="text-sm font-semibold uppercase text-brand-600 dark:text-teal-200">
+              Source setup
+            </p>
+            <h2 className="mt-3 max-w-3xl text-2xl font-bold leading-tight text-navy-700 dark:text-white">
+              Connect read-only billing sources and keep their evidence visible.
             </h2>
-            <div className="relative">
-              <button
-                onClick={() => setShowConfigModal(true)}
-                className="rounded bg-brand-500 px-4 py-2 text-sm text-white hover:bg-brand-600"
-              >
-                Add Account
-              </button>
-            </div>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-gray-700 dark:text-gray-300">
+              Linked accounts feed the dashboard with cost records, source
+              freshness, forecast context, and budget planning for every
+              configured source instance.
+            </p>
           </div>
 
-          {loading ? (
-            <div className="text-center py-4 text-gray-500">
-              Loading linked accounts...
+          <div className="grid rounded-lg border border-gray-200/80 bg-white shadow-sm shadow-shadow-500 dark:border-white/10 dark:bg-navy-800 dark:shadow-none">
+            <div className="border-b border-gray-200/80 p-4 dark:border-white/10">
+              <p className="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
+                Supported sources
+              </p>
+              <p className="mt-1 text-2xl font-bold text-navy-700 dark:text-white">
+                {VENDOR_CONFIGS.length}
+              </p>
             </div>
-          ) : error ? (
-            <div className="text-center py-4 text-red-500">
-              {error}
+            <div className="grid grid-cols-2 divide-x divide-gray-200/80 dark:divide-white/10">
+              <div className="p-4">
+                <p className="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
+                  Connected
+                </p>
+                <p className="mt-1 text-xl font-bold text-navy-700 dark:text-white">
+                  {linkedConfigurations.length}
+                </p>
+              </div>
+              <div className="p-4">
+                <p className="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
+                  Status
+                </p>
+                <p className="mt-1 text-xl font-bold text-navy-700 dark:text-white">
+                  {hasLinkedSources ? "Ready" : "Setup"}
+                </p>
+              </div>
             </div>
-          ) : configurations.length === 0 ? (
-            <div className="text-center py-8">
-              <p className="text-gray-500 mb-4">No linked accounts found</p>
+          </div>
+        </section>
+
+        {loading ? (
+          <div className="rounded-lg border border-gray-200/80 bg-white p-6 text-sm text-gray-600 shadow-sm shadow-shadow-500 dark:border-white/10 dark:bg-navy-800 dark:text-gray-300 dark:shadow-none">
+            Loading linked sources...
+          </div>
+        ) : error ? (
+          <div className="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 p-5 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-900/20 dark:text-red-100">
+            <MdErrorOutline className="mt-0.5 h-5 w-5 shrink-0" aria-hidden="true" />
+            <p>{error}</p>
+          </div>
+        ) : (
+          <>
+            <section
+              id="source-picker"
+              className="grid gap-4 md:grid-cols-3"
+              aria-label="Available cost sources"
+            >
+              {VENDOR_CONFIGS.map((vendor) => {
+                const vendorConfigurations = getConfigurationsByType(
+                  vendor.type
+                );
+                const isConnected = vendorConfigurations.length > 0;
+                const accountCount = vendorConfigurations.length;
+                const accountLabel =
+                  accountCount === 1
+                    ? "1 linked account"
+                    : `${accountCount} linked accounts`;
+
+                return (
+                  <button
+                    key={vendor.id}
+                    type="button"
+                    onClick={() => setSelectedSource({ vendor })}
+                    className="group flex min-h-[260px] flex-col rounded-lg border border-gray-200/80 bg-white p-5 text-left shadow-sm shadow-shadow-500 transition-colors hover:border-brand-200 hover:bg-brand-50/40 dark:border-white/10 dark:bg-navy-800 dark:shadow-none dark:hover:border-teal-300/40 dark:hover:bg-white/5"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex h-11 w-11 items-center justify-center rounded-md bg-brand-50 text-brand-600 ring-1 ring-brand-100 dark:bg-brand-500/10 dark:text-teal-200 dark:ring-brand-400/20">
+                        {vendor.icon}
+                      </div>
+                      <span
+                        className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold ${
+                          isConnected
+                            ? "bg-green-50 text-green-700 dark:bg-green-500/10 dark:text-green-200"
+                            : "bg-gray-100 text-gray-700 dark:bg-white/10 dark:text-gray-300"
+                        }`}
+                      >
+                        {isConnected && (
+                          <MdCheckCircle className="h-4 w-4" aria-hidden="true" />
+                        )}
+                        {isConnected ? accountLabel : "Not connected"}
+                      </span>
+                    </div>
+
+                    <div className="mt-5 flex-1">
+                      <h3 className="text-lg font-bold text-navy-700 dark:text-white">
+                        {vendor.name}
+                      </h3>
+                      <p className="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">
+                        {vendor.description}
+                      </p>
+                      <div className="mt-4 space-y-3 border-t border-gray-200/80 pt-4 dark:border-white/10">
+                        <div>
+                          <p className="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
+                            Credentials
+                          </p>
+                          <p className="mt-1 text-sm text-navy-700 dark:text-white">
+                            {vendor.credentials}
+                          </p>
+                        </div>
+                        <div>
+                          <p className="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
+                            Evidence
+                          </p>
+                          <p className="mt-1 text-sm leading-5 text-navy-700 dark:text-white">
+                            {vendor.evidence}
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="mt-5 flex items-center justify-between gap-3 border-t border-gray-200/80 pt-4 dark:border-white/10">
+                      <p className="min-w-0 truncate text-sm font-medium text-gray-600 dark:text-gray-300">
+                        {isConnected ? accountLabel : "Not connected"}
+                      </p>
+                      <span className="inline-flex shrink-0 items-center gap-2 text-sm font-semibold text-brand-600 group-hover:text-brand-700 dark:text-teal-200">
+                        <MdAddCircleOutline
+                          className="h-4 w-4"
+                          aria-hidden="true"
+                        />
+                        {isConnected ? "Add another" : "Connect"}
+                      </span>
+                    </div>
+                  </button>
+                );
+              })}
+            </section>
+
+            {hasLinkedSources ? (
+              <section className="rounded-lg border border-gray-200/80 bg-white p-5 shadow-sm shadow-shadow-500 dark:border-white/10 dark:bg-navy-800 dark:shadow-none">
+                <div className="mb-4 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+                  <div>
+                    <h2 className="text-lg font-bold text-navy-700 dark:text-white">
+                      Connected sources
+                    </h2>
+                    <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                      Account identity stays paired with the source that feeds
+                      dashboard metrics and forecasts.
+                    </p>
+                  </div>
+                  <Link
+                    to="/admin/default"
+                    className="inline-flex w-fit items-center gap-2 rounded-md border border-gray-200 px-3 py-2 text-sm font-semibold text-navy-700 transition-colors hover:border-brand-200 hover:bg-brand-50 dark:border-white/10 dark:text-white dark:hover:bg-white/10"
+                  >
+                    <MdDashboard className="h-4 w-4" aria-hidden="true" />
+                    View dashboard
+                  </Link>
+                </div>
+
+                <div className="divide-y divide-gray-200/80 dark:divide-white/10">
+                  {linkedConfigurations.map(({ config, vendor }) => (
+                    <div
+                      key={`${config.type}-${config.id}`}
+                      className="grid gap-4 py-4 md:grid-cols-[minmax(180px,0.5fr)_minmax(0,1fr)_auto] md:items-center"
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-brand-50 text-brand-600 ring-1 ring-brand-100 dark:bg-brand-500/10 dark:text-teal-200 dark:ring-brand-400/20">
+                          {vendor.icon}
+                        </div>
+                        <div>
+                          <p className="font-semibold text-navy-700 dark:text-white">
+                            {vendor.name}
+                          </p>
+                          <p className="text-xs uppercase text-green-700 dark:text-green-200">
+                            Connected
+                          </p>
+                        </div>
+                      </div>
+
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-navy-700 dark:text-white">
+                          {config.identifier}
+                        </p>
+                        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                          {vendor.evidence}
+                        </p>
+                      </div>
+
+                      <button
+                        type="button"
+                        onClick={() => setSelectedSource({ vendor, config })}
+                        className="inline-flex w-fit items-center gap-2 rounded-md bg-brand-500 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-600"
+                      >
+                        <MdEdit className="h-4 w-4" aria-hidden="true" />
+                        Edit
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ) : (
+              <section className="rounded-lg border border-dashed border-brand-200 bg-brand-50/50 p-5 dark:border-teal-300/30 dark:bg-white/5">
+                <p className="text-sm font-semibold text-brand-700 dark:text-teal-200">
+                  Start with one read-only source.
+                </p>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-gray-700 dark:text-gray-300">
+                  Once a source is connected, the dashboard can show cost
+                  evidence with freshness and forecast context instead of an
+                  empty setup state.
+                </p>
+              </section>
+            )}
+          </>
+        )}
+      </div>
+
+      {selectedSource && (
+        <div
+          className="fixed inset-0 z-50 flex justify-end"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="source-drawer-title"
+        >
+          <button
+            type="button"
+            className="absolute inset-0 bg-navy-900/70"
+            onClick={() => setSelectedSource(null)}
+            aria-label="Close source setup"
+          />
+          <aside className="relative flex h-full w-full max-w-xl flex-col overflow-y-auto bg-white p-6 shadow-2xl dark:bg-navy-800">
+            <div className="mb-6 flex items-start justify-between gap-4 border-b border-gray-200 pb-5 dark:border-white/10">
+              <div>
+                <p className="text-sm font-semibold uppercase text-brand-600 dark:text-teal-200">
+                  Source credentials
+                </p>
+                <h2
+                  id="source-drawer-title"
+                  className="mt-2 text-2xl font-bold text-navy-700 dark:text-white"
+                >
+                  {selectedSource.config
+                    ? `Edit ${selectedSource.vendor.name} account`
+                    : getConfigurationsByType(selectedSource.vendor.type).length > 0
+                    ? `Add another ${selectedSource.vendor.name} account`
+                    : `Connect ${selectedSource.vendor.name}`}
+                </h2>
+                <p className="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">
+                  {selectedSource.config?.identifier ||
+                    selectedSource.vendor.description}
+                </p>
+              </div>
               <button
-                onClick={() => setShowConfigModal(true)}
-                className="rounded bg-brand-500 px-4 py-2 text-sm text-white hover:bg-brand-600"
+                type="button"
+                onClick={() => setSelectedSource(null)}
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-gray-200 text-gray-600 transition-colors hover:border-brand-200 hover:bg-brand-50 dark:border-white/10 dark:text-gray-300 dark:hover:bg-white/10"
+                aria-label="Close source setup"
               >
-                Add Your First Linked Account
+                <MdClose className="h-5 w-5" aria-hidden="true" />
               </button>
             </div>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead>
-                  <tr className="border-b border-gray-200">
-                    <th className="p-2 text-left">Vendor</th>
-                    <th className="p-2 text-left">Identifier</th>
-                    <th className="p-2 text-right">Actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {configurations.map((config) => {
-                    const vendor = getVendorByType(config.type);
-                    if (!vendor) return null;
-                    
-                    return (
-                      <tr key={`${config.type}-${config.id}`} className="border-b border-gray-200">
-                        <td className="p-2 capitalize">{vendor.name}</td>
-                        <td className="p-2">{config.identifier}</td>
-                        <td className="p-2 text-right">
-                          <button
-                            onClick={() => handleConfigureVendor(vendor)}
-                            className="rounded bg-brand-500 px-3 py-1 text-sm text-white hover:bg-brand-600"
-                          >
-                            Edit
-                          </button>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </div>
-      </Card>
 
-      {showConfigModal && (
-        <Modal
-          isOpen={showConfigModal}
-          onClose={handleCloseModal}
-          title={selectedVendor ? 
-            `${configurations.some(c => c.type === selectedVendor.type) ? "Update" : "Add"} ${selectedVendor.name} Account` :
-            "Add New Account"
-          }
-        >
-          {selectedVendor ? (
-            React.createElement(selectedVendor.component, {
+            {React.createElement(selectedSource.vendor.component, {
               onConfigured: () => {
                 refresh();
-                handleCloseModal();
+                setSelectedSource(null);
               },
-              existingConfig: configurations.some(c => c.type === selectedVendor.type),
-            })
-          ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {VENDOR_CONFIGS.map((vendor) => (
-                <button
-                  key={vendor.id}
-                  onClick={() => setSelectedVendor(vendor)}
-                  className="p-4 border rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors dark:border-white/10"
-                >
-                  <h3 className="font-bold mb-2 text-navy-700 dark:text-white">{vendor.name}</h3>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
-                    Configure {vendor.name} integration
-                  </p>
-                </button>
-              ))}
-            </div>
-          )}
-        </Modal>
+              existingConfig: Boolean(selectedSource.config),
+              initialIdentifier:
+                selectedSource.config?.identifier ||
+                getDefaultIdentifier(selectedSource.vendor),
+              lockIdentifier: Boolean(selectedSource.config),
+            })}
+          </aside>
+        </div>
       )}
     </>
   );

--- a/dashboard/src/views/admin/default/components/AWSConfig.tsx
+++ b/dashboard/src/views/admin/default/components/AWSConfig.tsx
@@ -1,21 +1,31 @@
-import Card from "components/card";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { CallBackendService } from "utils";
 
 interface AWSConfigProps {
   onConfigured?: () => void;
   existingConfig?: boolean;
+  initialIdentifier?: string;
+  lockIdentifier?: boolean;
 }
 
-const AWSConfig: React.FC<AWSConfigProps> = ({ onConfigured, existingConfig }) => {
+const AWSConfig: React.FC<AWSConfigProps> = ({
+  onConfigured,
+  existingConfig,
+  initialIdentifier = "Default Configuration",
+  lockIdentifier,
+}) => {
   const [accessKeyId, setAccessKeyId] = useState("");
   const [secretAccessKey, setSecretAccessKey] = useState("");
-  const [identifier, setIdentifier] = useState('Default Configuration');
+  const [identifier, setIdentifier] = useState(initialIdentifier);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const { getAccessTokenSilently } = useAuth0();
+
+  useEffect(() => {
+    setIdentifier(initialIdentifier);
+  }, [initialIdentifier]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -55,12 +65,12 @@ const AWSConfig: React.FC<AWSConfigProps> = ({ onConfigured, existingConfig }) =
   };
 
   return (
-    <Card extra="!p-[20px] text-center">
+    <div>
       <div className="relative flex flex-row justify-between">
         <div className="flex items-center">
-          <div className="flex h-9 w-9 items-center justify-center rounded-full bg-indigo-100 dark:bg-indigo-100 dark:bg-white/5">
+          <div className="flex h-9 w-9 items-center justify-center rounded-md bg-brand-50 text-brand-600 ring-1 ring-brand-100 dark:bg-brand-500/10 dark:text-teal-200 dark:ring-brand-400/20">
             <svg
-              className="h-6 w-6 text-brand-500 dark:text-white"
+              className="h-6 w-6"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -82,42 +92,57 @@ const AWSConfig: React.FC<AWSConfigProps> = ({ onConfigured, existingConfig }) =
       <div className="mt-8 w-full">
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="flex flex-col">
-            <label className="mb-2 text-sm font-medium text-gray-900 dark:text-white">
+            <label
+              htmlFor="aws-access-key-id"
+              className="mb-2 text-sm font-medium text-gray-900 dark:text-white"
+            >
               AWS Access Key ID
             </label>
             <input
+              id="aws-access-key-id"
               type="text"
               value={accessKeyId}
               onChange={(e) => setAccessKeyId(e.target.value)}
-              className="mt-2 flex h-12 w-full items-center justify-center rounded-xl border bg-white/0 p-3 text-sm outline-none border-gray-200 dark:!border-white/10 dark:text-white"
+              className="mt-2 flex h-12 w-full items-center justify-center rounded-md border border-gray-200 bg-white/0 p-3 text-sm outline-none dark:!border-white/10 dark:text-white"
               placeholder="Enter AWS Access Key ID"
               required
             />
           </div>
 
           <div className="flex flex-col">
-            <label className="mb-2 text-sm font-medium text-gray-900 dark:text-white">
+            <label
+              htmlFor="aws-secret-access-key"
+              className="mb-2 text-sm font-medium text-gray-900 dark:text-white"
+            >
               AWS Secret Access Key
             </label>
             <input
+              id="aws-secret-access-key"
               type="password"
               value={secretAccessKey}
               onChange={(e) => setSecretAccessKey(e.target.value)}
-              className="mt-2 flex h-12 w-full items-center justify-center rounded-xl border bg-white/0 p-3 text-sm outline-none border-gray-200 dark:!border-white/10 dark:text-white"
+              className="mt-2 flex h-12 w-full items-center justify-center rounded-md border border-gray-200 bg-white/0 p-3 text-sm outline-none dark:!border-white/10 dark:text-white"
               placeholder="Enter AWS Secret Access Key"
               required
             />
           </div>
 
           <div className="flex flex-col">
-            <label className="mb-2 text-sm font-medium text-gray-900 dark:text-white">
+            <label
+              htmlFor="aws-configuration-name"
+              className="mb-2 text-sm font-medium text-gray-900 dark:text-white"
+            >
               Configuration Name
             </label>
             <input
+              id="aws-configuration-name"
               type="text"
               value={identifier}
               onChange={(e) => setIdentifier(e.target.value)}
-              className="mt-2 flex h-12 w-full items-center justify-center rounded-xl border bg-white/0 p-3 text-sm outline-none border-gray-200 dark:!border-white/10 dark:text-white"
+              readOnly={lockIdentifier}
+              className={`mt-2 flex h-12 w-full items-center justify-center rounded-md border border-gray-200 bg-white/0 p-3 text-sm outline-none dark:!border-white/10 dark:text-white ${
+                lockIdentifier ? "cursor-not-allowed bg-gray-100/50 dark:bg-white/5" : ""
+              }`}
               placeholder="Enter configuration name"
               required
             />
@@ -138,16 +163,16 @@ const AWSConfig: React.FC<AWSConfigProps> = ({ onConfigured, existingConfig }) =
           <button
             type="submit"
             disabled={loading}
-            className={`linear mt-4 w-full rounded-xl bg-brand-500 px-4 py-3 text-base font-medium text-white transition duration-200 hover:bg-brand-600 active:bg-brand-700 dark:bg-brand-400 dark:text-white dark:hover:bg-brand-300 dark:active:bg-brand-200 ${
+            className={`linear mt-4 w-full rounded-md bg-brand-500 px-4 py-3 text-base font-medium text-white transition duration-200 hover:bg-brand-600 active:bg-brand-700 dark:bg-brand-400 dark:text-white dark:hover:bg-brand-300 dark:active:bg-brand-200 ${
               loading ? "cursor-not-allowed opacity-50" : ""
             }`}
           >
-            {loading ? "Configuring..." : "Configure AWS"}
+            {loading ? "Configuring..." : existingConfig ? "Update AWS" : "Configure AWS"}
           </button>
         </form>
       </div>
-    </Card>
+    </div>
   );
 };
 
-export default AWSConfig; 
+export default AWSConfig;

--- a/dashboard/src/views/admin/default/components/DatadogConfig.tsx
+++ b/dashboard/src/views/admin/default/components/DatadogConfig.tsx
@@ -1,21 +1,31 @@
-import Card from "components/card";
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAuth0 } from "@auth0/auth0-react";
 import { CallBackendService } from "utils";
 
 interface DatadogConfigProps {
   onConfigured?: () => void;
   existingConfig?: boolean;
+  initialIdentifier?: string;
+  lockIdentifier?: boolean;
 }
 
-const DatadogConfig: React.FC<DatadogConfigProps> = ({ onConfigured, existingConfig }) => {
+const DatadogConfig: React.FC<DatadogConfigProps> = ({
+  onConfigured,
+  existingConfig,
+  initialIdentifier = "Default Configuration",
+  lockIdentifier,
+}) => {
   const [appKey, setAppKey] = useState('');
   const [apiKey, setApiKey] = useState('');
-  const [identifier, setIdentifier] = useState('Default Configuration');
+  const [identifier, setIdentifier] = useState(initialIdentifier);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const { getAccessTokenSilently } = useAuth0();
+
+  useEffect(() => {
+    setIdentifier(initialIdentifier);
+  }, [initialIdentifier]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -55,12 +65,12 @@ const DatadogConfig: React.FC<DatadogConfigProps> = ({ onConfigured, existingCon
   };
 
   return (
-    <Card extra="!p-[20px] text-center">
+    <div>
       <div className="relative flex flex-row justify-between">
         <div className="flex items-center">
-          <div className="flex h-9 w-9 items-center justify-center rounded-full bg-indigo-100 dark:bg-indigo-100 dark:bg-white/5">
+          <div className="flex h-9 w-9 items-center justify-center rounded-md bg-brand-50 text-brand-600 ring-1 ring-brand-100 dark:bg-brand-500/10 dark:text-teal-200 dark:ring-brand-400/20">
             <svg
-              className="h-6 w-6 text-brand-500 dark:text-white"
+              className="h-6 w-6"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -82,42 +92,57 @@ const DatadogConfig: React.FC<DatadogConfigProps> = ({ onConfigured, existingCon
       <div className="mt-8 w-full">
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="flex flex-col">
-            <label className="mb-2 text-sm font-medium text-gray-900 dark:text-white">
-              Datadog App Key {existingConfig && "(leave blank to keep current)"}
+            <label
+              htmlFor="datadog-app-key"
+              className="mb-2 text-sm font-medium text-gray-900 dark:text-white"
+            >
+              Datadog App Key
             </label>
             <input
+              id="datadog-app-key"
               type="password"
               value={appKey}
               onChange={(e) => setAppKey(e.target.value)}
-              className="mt-2 flex h-12 w-full items-center justify-center rounded-xl border bg-white/0 p-3 text-sm outline-none border-gray-200 dark:!border-white/10 dark:text-white"
+              className="mt-2 flex h-12 w-full items-center justify-center rounded-md border border-gray-200 bg-white/0 p-3 text-sm outline-none dark:!border-white/10 dark:text-white"
               placeholder={existingConfig ? "Enter new Datadog App Key" : "Enter Datadog App Key"}
-              required={!existingConfig}
+              required
             />
           </div>
 
           <div className="flex flex-col">
-            <label className="mb-2 text-sm font-medium text-gray-900 dark:text-white">
-              Datadog API Key {existingConfig && "(leave blank to keep current)"}
+            <label
+              htmlFor="datadog-api-key"
+              className="mb-2 text-sm font-medium text-gray-900 dark:text-white"
+            >
+              Datadog API Key
             </label>
             <input
+              id="datadog-api-key"
               type="password"
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
-              className="mt-2 flex h-12 w-full items-center justify-center rounded-xl border bg-white/0 p-3 text-sm outline-none border-gray-200 dark:!border-white/10 dark:text-white"
+              className="mt-2 flex h-12 w-full items-center justify-center rounded-md border border-gray-200 bg-white/0 p-3 text-sm outline-none dark:!border-white/10 dark:text-white"
               placeholder={existingConfig ? "Enter new Datadog API Key" : "Enter Datadog API Key"}
-              required={!existingConfig}
+              required
             />
           </div>
 
           <div className="flex flex-col">
-            <label className="mb-2 text-sm font-medium text-gray-900 dark:text-white">
+            <label
+              htmlFor="datadog-configuration-name"
+              className="mb-2 text-sm font-medium text-gray-900 dark:text-white"
+            >
               Configuration Name
             </label>
             <input
+              id="datadog-configuration-name"
               type="text"
               value={identifier}
               onChange={(e) => setIdentifier(e.target.value)}
-              className="mt-2 flex h-12 w-full items-center justify-center rounded-xl border bg-white/0 p-3 text-sm outline-none border-gray-200 dark:!border-white/10 dark:text-white"
+              readOnly={lockIdentifier}
+              className={`mt-2 flex h-12 w-full items-center justify-center rounded-md border border-gray-200 bg-white/0 p-3 text-sm outline-none dark:!border-white/10 dark:text-white ${
+                lockIdentifier ? "cursor-not-allowed bg-gray-100/50 dark:bg-white/5" : ""
+              }`}
               placeholder="Enter configuration name"
               required
             />
@@ -138,7 +163,7 @@ const DatadogConfig: React.FC<DatadogConfigProps> = ({ onConfigured, existingCon
           <button
             type="submit"
             disabled={loading}
-            className={`linear mt-4 w-full rounded-xl bg-brand-500 px-4 py-3 text-base font-medium text-white transition duration-200 hover:bg-brand-600 active:bg-brand-700 dark:bg-brand-400 dark:text-white dark:hover:bg-brand-300 dark:active:bg-brand-200 ${
+            className={`linear mt-4 w-full rounded-md bg-brand-500 px-4 py-3 text-base font-medium text-white transition duration-200 hover:bg-brand-600 active:bg-brand-700 dark:bg-brand-400 dark:text-white dark:hover:bg-brand-300 dark:active:bg-brand-200 ${
               loading ? "cursor-not-allowed opacity-50" : ""
             }`}
           >
@@ -146,7 +171,7 @@ const DatadogConfig: React.FC<DatadogConfigProps> = ({ onConfigured, existingCon
           </button>
         </form>
       </div>
-    </Card>
+    </div>
   );
 };
 

--- a/dashboard/src/views/admin/default/components/HerokuConfig.tsx
+++ b/dashboard/src/views/admin/default/components/HerokuConfig.tsx
@@ -1,24 +1,31 @@
-import Card from "components/card";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { CallBackendService } from "utils";
 
 interface HerokuConfigProps {
   onConfigured?: () => void;
   existingConfig?: boolean;
+  initialIdentifier?: string;
+  lockIdentifier?: boolean;
 }
 
 const HerokuConfig: React.FC<HerokuConfigProps> = ({
   onConfigured,
   existingConfig,
+  initialIdentifier = "Default Configuration",
+  lockIdentifier,
 }) => {
   const [apiKey, setApiKey] = useState("");
   const [teamNameOrId, setTeamNameOrId] = useState("");
-  const [identifier, setIdentifier] = useState("Default Configuration");
+  const [identifier, setIdentifier] = useState(initialIdentifier);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const { getAccessTokenSilently } = useAuth0();
+
+  useEffect(() => {
+    setIdentifier(initialIdentifier);
+  }, [initialIdentifier]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -60,12 +67,12 @@ const HerokuConfig: React.FC<HerokuConfigProps> = ({
   };
 
   return (
-    <Card extra="!p-[20px] text-center">
+    <div>
       <div className="relative flex flex-row justify-between">
         <div className="flex items-center">
-          <div className="flex h-9 w-9 items-center justify-center rounded-full bg-indigo-100 dark:bg-indigo-100 dark:bg-white/5">
+          <div className="flex h-9 w-9 items-center justify-center rounded-md bg-brand-50 text-brand-600 ring-1 ring-brand-100 dark:bg-brand-500/10 dark:text-teal-200 dark:ring-brand-400/20">
             <svg
-              className="h-6 w-6 text-brand-500 dark:text-white"
+              className="h-6 w-6"
               fill="currentColor"
               viewBox="0 0 24 24"
             >
@@ -81,41 +88,56 @@ const HerokuConfig: React.FC<HerokuConfigProps> = ({
       <div className="mt-8 w-full">
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="flex flex-col">
-            <label className="mb-2 text-sm font-medium text-gray-900 dark:text-white">
+            <label
+              htmlFor="heroku-api-key"
+              className="mb-2 text-sm font-medium text-gray-900 dark:text-white"
+            >
               Heroku API Key
             </label>
             <input
+              id="heroku-api-key"
               type="password"
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
-              className="mt-2 flex h-12 w-full items-center justify-center rounded-xl border bg-white/0 p-3 text-sm outline-none border-gray-200 dark:!border-white/10 dark:text-white"
+              className="mt-2 flex h-12 w-full items-center justify-center rounded-md border border-gray-200 bg-white/0 p-3 text-sm outline-none dark:!border-white/10 dark:text-white"
               placeholder="Enter Heroku API key"
               required
             />
           </div>
 
           <div className="flex flex-col">
-            <label className="mb-2 text-sm font-medium text-gray-900 dark:text-white">
+            <label
+              htmlFor="heroku-team-name-or-id"
+              className="mb-2 text-sm font-medium text-gray-900 dark:text-white"
+            >
               Team Name or ID
             </label>
             <input
+              id="heroku-team-name-or-id"
               type="text"
               value={teamNameOrId}
               onChange={(e) => setTeamNameOrId(e.target.value)}
-              className="mt-2 flex h-12 w-full items-center justify-center rounded-xl border bg-white/0 p-3 text-sm outline-none border-gray-200 dark:!border-white/10 dark:text-white"
+              className="mt-2 flex h-12 w-full items-center justify-center rounded-md border border-gray-200 bg-white/0 p-3 text-sm outline-none dark:!border-white/10 dark:text-white"
               placeholder="Leave blank for personal account invoices"
             />
           </div>
 
           <div className="flex flex-col">
-            <label className="mb-2 text-sm font-medium text-gray-900 dark:text-white">
+            <label
+              htmlFor="heroku-configuration-name"
+              className="mb-2 text-sm font-medium text-gray-900 dark:text-white"
+            >
               Configuration Name
             </label>
             <input
+              id="heroku-configuration-name"
               type="text"
               value={identifier}
               onChange={(e) => setIdentifier(e.target.value)}
-              className="mt-2 flex h-12 w-full items-center justify-center rounded-xl border bg-white/0 p-3 text-sm outline-none border-gray-200 dark:!border-white/10 dark:text-white"
+              readOnly={lockIdentifier}
+              className={`mt-2 flex h-12 w-full items-center justify-center rounded-md border border-gray-200 bg-white/0 p-3 text-sm outline-none dark:!border-white/10 dark:text-white ${
+                lockIdentifier ? "cursor-not-allowed bg-gray-100/50 dark:bg-white/5" : ""
+              }`}
               placeholder="Enter configuration name"
               required
             />
@@ -136,7 +158,7 @@ const HerokuConfig: React.FC<HerokuConfigProps> = ({
           <button
             type="submit"
             disabled={loading}
-            className={`linear mt-4 w-full rounded-xl bg-brand-500 px-4 py-3 text-base font-medium text-white transition duration-200 hover:bg-brand-600 active:bg-brand-700 dark:bg-brand-400 dark:text-white dark:hover:bg-brand-300 dark:active:bg-brand-200 ${
+            className={`linear mt-4 w-full rounded-md bg-brand-500 px-4 py-3 text-base font-medium text-white transition duration-200 hover:bg-brand-600 active:bg-brand-700 dark:bg-brand-400 dark:text-white dark:hover:bg-brand-300 dark:active:bg-brand-200 ${
               loading ? "cursor-not-allowed opacity-50" : ""
             }`}
           >
@@ -148,7 +170,7 @@ const HerokuConfig: React.FC<HerokuConfigProps> = ({
           </button>
         </form>
       </div>
-    </Card>
+    </div>
   );
 };
 

--- a/dashboard/src/views/admin/default/index.tsx
+++ b/dashboard/src/views/admin/default/index.tsx
@@ -55,10 +55,10 @@ const Dashboard = () => {
 
   if (visibleConfigurations.length === 0) {
     return (
-      <div className="mx-auto mt-3 max-w-[1180px]">
+      <div className="mx-auto mt-3 max-w-[1080px]">
         <Card extra="overflow-hidden !p-0">
-          <div className="grid gap-0 lg:grid-cols-[1.2fr_0.8fr]">
-            <section className="p-8">
+          <div className="grid gap-8 p-6 md:p-8 lg:grid-cols-[minmax(0,1fr)_minmax(280px,340px)] lg:items-start">
+            <section className="max-w-[720px]">
               <p className="text-sm font-semibold uppercase text-brand-600 dark:text-teal-200">
                 InfraSpend setup
               </p>
@@ -79,21 +79,21 @@ const Dashboard = () => {
                 Link an account
               </Link>
             </section>
-            <aside className="border-t border-gray-200 bg-gray-50 p-8 dark:border-white/10 dark:bg-white/5 lg:border-l lg:border-t-0">
+            <aside className="max-w-xl border-t border-gray-200/80 pt-6 dark:border-white/10 lg:max-w-none lg:border-l-2 lg:border-t-0 lg:border-brand-200/60 lg:py-1 lg:pl-6 dark:lg:border-teal-300/40">
               <h2 className="text-sm font-bold uppercase text-gray-500 dark:text-gray-400">
                 Setup checklist
               </h2>
-              <div className="mt-5 space-y-5">
+              <div className="mt-4 space-y-3">
                 {[
                   "Read-only provider credentials",
                   "Current source freshness",
                   "Budget plan from forecast data",
                 ].map((item, index) => (
-                  <div key={item} className="flex gap-3">
-                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-white text-sm font-bold text-brand-700 ring-1 ring-gray-200 dark:bg-navy-900 dark:text-teal-200 dark:ring-white/10">
+                  <div key={item} className="flex items-start gap-3">
+                    <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-brand-50 text-sm font-bold text-brand-700 ring-1 ring-brand-100 dark:bg-navy-900 dark:text-teal-200 dark:ring-white/10">
                       {index + 1}
                     </span>
-                    <p className="text-sm font-medium text-navy-700 dark:text-white">
+                    <p className="text-sm font-medium leading-6 text-navy-700 dark:text-white">
                       {item}
                     </p>
                   </div>


### PR DESCRIPTION
## Summary
- Redesign the linked accounts page as a source setup workspace instead of a generic configuration table/modal.
- Make provider cards additive so a workspace can link multiple AWS, Datadog, or Heroku account instances.
- Move credential entry into a right-side drawer and keep edit actions scoped to the selected account identifier.
- Tighten the dashboard empty setup card composition.

## Validation
- `npm run build`
- `npm test -- --watchAll=false --runInBand`
- `git diff --check`

## Notes
- Local Auth0/backend configuration is unavailable in this worktree, so visual checks used the compiled app shell plus DOM previews for empty and drawer states.